### PR TITLE
Fix auth security: scoped RLS, ownership enforcement, and UX improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key-here
+VITE_GOOGLE_CLIENT_ID=your-oauth-client-id.apps.googleusercontent.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          NODE_ENV: production
+          VITE_SUPABASE_URL:      ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_GOOGLE_CLIENT_ID:  ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.env.local
+.env.*.local

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=otygtgvegbcwwuaynkqt"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev        # Start Vite dev server at http://localhost:5173/
+npm run build      # Production build → dist/  (sets NODE_ENV=production)
+npm run preview    # Preview the production build locally
+```
+
+There are no tests or linters configured.
+
+## Architecture
+
+This is a **Vite + Vanilla JS** single-page application — no framework. The original prototype was a single HTML file (`base`, kept for reference); it was modularised into ES modules under `src/`.
+
+### Startup sequence (`src/main.js`)
+
+`init()` runs in order:
+1. `initConfig()` — fetches `public/config.json` (admin-controlled release schedule)
+2. `initState()` — hydrates mutable `state` object from `localStorage`
+3. `initAuth()` — connects to Supabase if env vars are present, loads roadmap list
+4. Renders the Gantt chart
+
+All functions called from inline `onclick` attributes in dynamically generated HTML are explicitly assigned to `window` in `main.js`. This is intentional — do not move them to module-only scope.
+
+### State (`src/state.js`)
+
+A single mutable `state` object is the source of truth:
+```js
+state.workstreams  // array of { id, name, color }
+state.features     // array of { id, ws, name, start, end, status }
+state.nextId       // auto-increment for new features
+state.currentRoadmapId / currentRoadmapName
+```
+
+Every mutation must call `persistState()` afterward. It writes to `localStorage` and (when Supabase is configured) `saveRoadmap()` syncs to the database. The 7 mutation sites are: `saveFeature`, `deleteFeature`, `saveWorkstream`, `deleteWorkstream`, `dropOn`, `stopResize`, `cellClick`.
+
+### Configuration (`public/config.json` + `src/config.js`)
+
+Release schedule, statuses, months, and column dimensions live in `public/config.json`. Admins edit this file and redeploy — CSMs never touch it. `getConfig()` is imported everywhere constants are needed; never hardcode these values.
+
+Month indices are 0–11 (FEB=0 … JAN=11). Feature `start`/`end` fields are month indices.
+
+### Supabase (`src/auth.js`)
+
+Supabase is **optional** — the app runs fully offline using `localStorage` when `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` are absent. When configured:
+- Auth: magic link (OTP) via `supabase.auth.signInWithOtp`
+- Table: `roadmaps` — workstreams and features stored as JSONB columns
+- Realtime: subscribed per roadmap UUID via `subscribeRealtime(id)`; live updates overwrite local state and re-render
+- Schema: `supabase/schema.sql` — run once in the Supabase SQL editor; also enable Realtime on the `roadmaps` table in the dashboard
+
+### Export
+
+- **PowerPoint** (`src/export/exportPptx.js`): Uses `pptxgenjs` entirely in-browser. Slide layout constants are at the top of the file (inches). Overflow to a second slide is handled recursively via `buildSlide()`.
+- **Google Slides** (`src/export/exportGoogleSlides.js`): Loads `gapi` and `google.accounts.oauth2` at runtime via script tags. Requires `VITE_GOOGLE_CLIENT_ID`. Gracefully alerts if the env var is missing. The slide content is built as a `batchUpdate` request list using EMU units (1 inch = 914400 EMU).
+
+### Deployment
+
+GitHub Actions (`.github/workflows/deploy.yml`) builds on push to `main` and deploys `dist/` to the `gh-pages` branch. The three env vars (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_GOOGLE_CLIENT_ID`) must be set as GitHub repository secrets before deploying.
+
+`vite.config.js` sets `base: '/deployment-roadmap-builder/'` in production so assets resolve correctly on GitHub Pages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,10 +47,11 @@ Month indices are 0–11 (FEB=0 … JAN=11). Feature `start`/`end` fields are mo
 ### Supabase (`src/auth.js`)
 
 Supabase is **optional** — the app runs fully offline using `localStorage` when `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` are absent. When configured:
-- Auth: magic link (OTP) via `supabase.auth.signInWithOtp`
+- Auth: magic link (OTP) via `supabase.auth.signInWithOtp`; session is verified server-side via `supabase.auth.getUser()` (not `getSession()`)
 - Table: `roadmaps` — workstreams and features stored as JSONB columns
+- RLS: four per-operation policies scoped to `created_by = auth.uid()`; users can only read/write their own roadmaps
 - Realtime: subscribed per roadmap UUID via `subscribeRealtime(id)`; live updates overwrite local state and re-render
-- Schema: `supabase/schema.sql` — run once in the Supabase SQL editor; also enable Realtime on the `roadmaps` table in the dashboard
+- Schema: `supabase/schema.sql` — already applied to the dev project via MCP migration; run manually in the SQL editor for new environments. Also enable Realtime on the `roadmaps` table in the Supabase dashboard (Table Editor → roadmaps → Realtime → Enable) — this cannot be done via SQL.
 
 ### Export
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Deployment Roadmap Builder</title>
+</head>
+<body>
+
+  <!-- Auth bar (visible only when Supabase is configured) -->
+  <div class="auth-bar" id="auth-bar"></div>
+
+  <!-- Roadmap selector row -->
+  <div class="roadmap-bar" id="roadmap-bar">
+    <label for="roadmap-name">Roadmap:</label>
+    <input type="text" id="roadmap-name" class="roadmap-name-input" placeholder="Customer / roadmap name" />
+    <select id="roadmap-select" onchange="handleRoadmapSelect(event)" style="display:none">
+      <option value="">— New roadmap —</option>
+    </select>
+    <button onclick="saveRoadmap()" class="primary" style="font-size:12px;padding:4px 12px">Save</button>
+    <button onclick="newRoadmap()" style="font-size:12px;padding:4px 12px">New</button>
+    <div style="flex:1"></div>
+    <button onclick="exportStateAsJson()" title="Export roadmap as JSON for sharing">⬇ Export JSON</button>
+    <label style="cursor:pointer;font-size:12px;padding:5px 10px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary)">
+      ⬆ Import JSON
+      <input type="file" accept=".json" onchange="handleJsonImport(event)" style="display:none" />
+    </label>
+  </div>
+
+  <!-- Main toolbar -->
+  <div class="toolbar">
+    <button class="primary" onclick="openAddFeature()">+ Add feature</button>
+    <button onclick="openAddWorkstream()">+ Add workstream</button>
+    <select id="filterWs" onchange="render()">
+      <option value="">All workstreams</option>
+    </select>
+    <select id="filterStatus" onchange="render()">
+      <option value="">All statuses</option>
+    </select>
+    <div style="flex:1"></div>
+    <button onclick="exportToPptx()">⬇ Export .pptx</button>
+    <button id="btn-google-slides" onclick="exportToGoogleSlides()">Export to Google Slides ↗</button>
+  </div>
+
+  <!-- Legend -->
+  <div class="legend" id="legend"></div>
+
+  <!-- Gantt grid -->
+  <div class="gantt-wrap"><div class="gantt" id="gantt"></div></div>
+
+  <!-- Feature modal -->
+  <div class="modal-bg" id="modal-bg">
+    <div class="modal">
+      <h3 id="modal-title">Add feature</h3>
+      <div class="form-row">
+        <label>Feature name</label>
+        <input type="text" id="f-name" placeholder="Feature name" />
+      </div>
+      <div class="form-row">
+        <label>Workstream</label>
+        <select id="f-ws"></select>
+      </div>
+      <div class="form-row">
+        <label>Status</label>
+        <select id="f-status"></select>
+      </div>
+      <div class="form-row">
+        <label>Start month</label>
+        <div class="month-grid" id="start-months"></div>
+      </div>
+      <div class="form-row">
+        <label>End month</label>
+        <div class="month-grid" id="end-months"></div>
+      </div>
+      <div class="modal-actions">
+        <button id="delete-btn" class="danger" style="margin-right:auto;display:none" onclick="deleteFeature()">Delete</button>
+        <button onclick="closeModal()">Cancel</button>
+        <button class="save" onclick="saveFeature()">Save</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Workstream modal -->
+  <div class="modal-bg" id="ws-modal-bg">
+    <div class="modal">
+      <h3 id="ws-modal-title">Add workstream</h3>
+      <div class="form-row">
+        <label>Workstream name</label>
+        <input type="text" id="ws-name-input" placeholder="e.g. Analytics" />
+      </div>
+      <div class="form-row">
+        <label>Color</label>
+        <select id="ws-color-input">
+          <option value="#4A6FA5">Blue</option>
+          <option value="#2E8B57">Green</option>
+          <option value="#B8621A">Orange</option>
+          <option value="#5B4B8A">Purple</option>
+          <option value="#C0392B">Red</option>
+          <option value="#16A085">Teal</option>
+          <option value="#7D6608">Olive</option>
+        </select>
+      </div>
+      <div class="modal-actions">
+        <button id="ws-delete-btn" class="danger" style="margin-right:auto;display:none" onclick="deleteWorkstream()">Delete workstream</button>
+        <button onclick="document.getElementById('ws-modal-bg').classList.remove('open')">Cancel</button>
+        <button class="save" onclick="saveWorkstream()">Save</button>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="/src/main.js"></script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1293 @@
+{
+  "name": "deployment-roadmap-builder",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "deployment-roadmap-builder",
+      "version": "0.1.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.45.0",
+        "pptxgenjs": "^3.12.0"
+      },
+      "devDependencies": {
+        "vite": "^5.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.104.0.tgz",
+      "integrity": "sha512-Vs0ndL+s5an7rOmXtS/nbYnGXL8m+KXlCSrPIcw9bR96ma6qyLYILnE6syuM+rpDnf+Tg4PVNxNB2+oDwoy6mA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.104.0.tgz",
+      "integrity": "sha512-O8EyEz/RT1kfWhyJNpVc/VbLeBsohHGBVif/CI83zoMB+Iul/t/NIekH1/7RsH6kuO+b2D4wJhfiaW8Qr47sRg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.104.0.tgz",
+      "integrity": "sha512-ynylEq6wduQEycj6pL3P+/yIfDQ+CTnBC5I6p+PzcAO2ybj9coAITVtMfboi+g/dacgMslN5MH73rXsRMB29+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.104.0.tgz",
+      "integrity": "sha512-9fUVDoTVAhn7a79+AmEx+asUlRtf2yBrji7TQckcKn/WK4hvAA9Lia9er+lnhuz3WNiF1x6kkA4x7bRCJrU+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.104.0.tgz",
+      "integrity": "sha512-s2NHtuAWb9nldJ/fS62WnJE6edvCWn31rrO+FJKlAohs99qdVgtLegUReTU2H9WnZiQlVqaBtu386wt6/6lrRw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.104.0.tgz",
+      "integrity": "sha512-hILwhIjCB53G31jlHUe73NDEmrXudcjcYlVRuvNfEhzf0gyFQaFf7j6rd1UGmYZkFMOg//DFE8Iy9ZbNEgosVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.104.0",
+        "@supabase/functions-js": "2.104.0",
+        "@supabase/postgrest-js": "2.104.0",
+        "@supabase/realtime-js": "2.104.0",
+        "@supabase/storage-js": "2.104.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
+      "license": "ISC"
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pptxgenjs": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/pptxgenjs/-/pptxgenjs-3.12.0.tgz",
+      "integrity": "sha512-ZozkYKWb1MoPR4ucw3/aFYlHkVIJxo9czikEclcUVnS4Iw/M+r+TEwdlB3fyAWO9JY1USxJDt0Y0/r15IR/RUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.7.3",
+        "https": "^1.0.0",
+        "image-size": "^1.0.0",
+        "jszip": "^3.7.1"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "deployment-roadmap-builder",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^5.4.0"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.0",
+    "pptxgenjs": "^3.12.0"
+  }
+}

--- a/public/config.json
+++ b/public/config.json
@@ -1,0 +1,20 @@
+{
+  "months": ["FEB","MAR","APR","MAY","JUN","JUL","AUG","SEP","OCT","NOV","DEC","JAN"],
+  "currentMonth": 2,
+  "colWidth": 60,
+  "labelWidth": 160,
+  "releases": [
+    { "label": "Winter 26", "start": 0, "end": 2,  "bg": "#DDE3F0" },
+    { "label": "Spring 26",  "start": 3, "end": 5,  "bg": "#C8E6C9" },
+    { "label": "Summer 26", "start": 6, "end": 8,  "bg": "#FFE0B2" },
+    { "label": "Winter 27", "start": 9, "end": 11, "bg": "#E1BEE7" }
+  ],
+  "statuses": [
+    { "id": "deployed",   "label": "Deployed",        "color": "#2E7D32", "fill": "#C8E6C9" },
+    { "id": "ready",      "label": "Ready to deploy",  "color": "#1565C0", "fill": "#BBDEFB" },
+    { "id": "poc",        "label": "POC / Pilot",      "color": "#E65100", "fill": "#FFE0B2" },
+    { "id": "exploring",  "label": "Exploring",        "color": "#6A1B9A", "fill": "#E1BEE7" },
+    { "id": "reqs",       "label": "Reqs gathering",   "color": "#AD1457", "fill": "#FCE4EC" },
+    { "id": "notstarted", "label": "Not started",      "color": "#546E7A", "fill": "#ECEFF1" }
+  ]
+}

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,167 @@
+import { createClient } from '@supabase/supabase-js';
+import { state, persistState } from './state.js';
+import { render } from './render.js';
+import { populateFilters } from './filters.js';
+
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+export let supabase = null;
+let currentUser = null;
+let realtimeChannel = null;
+
+export function isConfigured() {
+  return !!(SUPABASE_URL && SUPABASE_KEY);
+}
+
+export function getCurrentUser() {
+  return currentUser;
+}
+
+export async function initAuth() {
+  if (!isConfigured()) return;
+
+  supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+  const { data: { session } } = await supabase.auth.getSession();
+  currentUser = session?.user || null;
+  updateAuthBar();
+
+  supabase.auth.onAuthStateChange((_event, session) => {
+    currentUser = session?.user || null;
+    updateAuthBar();
+    if (currentUser) loadRoadmapList();
+  });
+
+  if (currentUser) await loadRoadmapList();
+}
+
+function updateAuthBar() {
+  const bar = document.getElementById('auth-bar');
+  if (!bar) return;
+  if (currentUser) {
+    bar.innerHTML = `
+      <span>${currentUser.email}</span>
+      <button onclick="signOut()">Sign out</button>
+    `;
+  } else {
+    bar.innerHTML = `
+      <span>Sign in to save & share roadmaps across your team</span>
+      <button onclick="showSignIn()">Sign in</button>
+    `;
+  }
+}
+
+export async function showSignIn() {
+  const email = prompt('Enter your email address to receive a sign-in link:');
+  if (!email || !supabase) return;
+  const { error } = await supabase.auth.signInWithOtp({ email });
+  if (error) alert(`Sign in failed: ${error.message}`);
+  else alert(`Check your email (${email}) for a sign-in link.`);
+}
+
+export async function signOut() {
+  if (!supabase) return;
+  await supabase.auth.signOut();
+  updateAuthBar();
+}
+
+// ── Roadmap CRUD ──────────────────────────────────────────────────────────────
+
+export async function loadRoadmapList() {
+  if (!supabase || !currentUser) return;
+  const { data, error } = await supabase.from('roadmaps').select('id, name, updated_at').order('updated_at', { ascending: false });
+  if (error) { console.error('Failed to load roadmaps:', error); return; }
+  renderRoadmapSelector(data || []);
+}
+
+function renderRoadmapSelector(roadmaps) {
+  const sel = document.getElementById('roadmap-select');
+  if (!sel) return;
+  sel.innerHTML = '<option value="">— New roadmap —</option>' +
+    roadmaps.map(r => `<option value="${r.id}">${r.name}</option>`).join('');
+  if (state.currentRoadmapId) sel.value = state.currentRoadmapId;
+}
+
+export async function loadRoadmap(id) {
+  if (!supabase || !id) return;
+  const { data, error } = await supabase.from('roadmaps').select('*').eq('id', id).single();
+  if (error) { console.error('Failed to load roadmap:', error); return; }
+  state.workstreams       = data.workstreams;
+  state.features          = data.features;
+  state.nextId            = data.next_id;
+  state.currentRoadmapId  = data.id;
+  state.currentRoadmapName = data.name;
+  const nameEl = document.getElementById('roadmap-name');
+  if (nameEl) nameEl.value = data.name;
+  populateFilters();
+  render();
+}
+
+export async function saveRoadmap() {
+  if (!supabase || !currentUser) {
+    persistState();
+    return;
+  }
+  const name = document.getElementById('roadmap-name')?.value?.trim() || state.currentRoadmapName || 'Untitled';
+  state.currentRoadmapName = name;
+
+  const payload = {
+    name,
+    workstreams: state.workstreams,
+    features:    state.features,
+    next_id:     state.nextId,
+    created_by:  currentUser.id,
+    updated_at:  new Date().toISOString(),
+  };
+
+  let result;
+  if (state.currentRoadmapId) {
+    result = await supabase.from('roadmaps').update(payload).eq('id', state.currentRoadmapId).select().single();
+  } else {
+    result = await supabase.from('roadmaps').insert(payload).select().single();
+  }
+
+  if (result.error) { console.error('Save failed:', result.error); return; }
+  state.currentRoadmapId = result.data.id;
+  await loadRoadmapList();
+  persistState();
+}
+
+export async function newRoadmap() {
+  if (!confirm('Start a new roadmap? Unsaved changes will be lost.')) return;
+  state.currentRoadmapId   = null;
+  state.currentRoadmapName = 'New Roadmap';
+  state.workstreams = [
+    { id: "staffing",   name: "Staffing",   color: "#4A6FA5" },
+    { id: "delivery",   name: "Delivery",   color: "#2E8B57" },
+    { id: "partners",   name: "Partners",   color: "#B8621A" },
+    { id: "operations", name: "Operations", color: "#5B4B8A" },
+  ];
+  state.features = [];
+  state.nextId   = 1;
+  const nameEl = document.getElementById('roadmap-name');
+  if (nameEl) nameEl.value = state.currentRoadmapName;
+  const sel = document.getElementById('roadmap-select');
+  if (sel) sel.value = '';
+  populateFilters();
+  render();
+  persistState();
+}
+
+export function subscribeRealtime(roadmapId) {
+  if (!supabase || !roadmapId) return;
+  if (realtimeChannel) supabase.removeChannel(realtimeChannel);
+  realtimeChannel = supabase
+    .channel(`roadmap:${roadmapId}`)
+    .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'roadmaps', filter: `id=eq.${roadmapId}` },
+      (payload) => {
+        if (payload.new.updated_at === payload.old.updated_at) return;
+        state.workstreams = payload.new.workstreams;
+        state.features    = payload.new.features;
+        state.nextId      = payload.new.next_id;
+        populateFilters();
+        render();
+      })
+    .subscribe();
+}

--- a/src/auth.js
+++ b/src/auth.js
@@ -23,8 +23,8 @@ export async function initAuth() {
 
   supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
-  const { data: { session } } = await supabase.auth.getSession();
-  currentUser = session?.user || null;
+  const { data: { user } } = await supabase.auth.getUser();
+  currentUser = user || null;
   updateAuthBar();
 
   supabase.auth.onAuthStateChange((_event, session) => {
@@ -81,6 +81,7 @@ function renderRoadmapSelector(roadmaps) {
   sel.innerHTML = '<option value="">— New roadmap —</option>' +
     roadmaps.map(r => `<option value="${r.id}">${r.name}</option>`).join('');
   if (state.currentRoadmapId) sel.value = state.currentRoadmapId;
+  sel.style.display = '';
 }
 
 export async function loadRoadmap(id) {
@@ -117,12 +118,19 @@ export async function saveRoadmap() {
 
   let result;
   if (state.currentRoadmapId) {
-    result = await supabase.from('roadmaps').update(payload).eq('id', state.currentRoadmapId).select().single();
+    result = await supabase.from('roadmaps').update(payload)
+      .eq('id', state.currentRoadmapId)
+      .eq('created_by', currentUser.id)
+      .select().single();
   } else {
     result = await supabase.from('roadmaps').insert(payload).select().single();
   }
 
-  if (result.error) { console.error('Save failed:', result.error); return; }
+  if (result.error) {
+    console.error('Save failed:', result.error);
+    alert(`Save failed: ${result.error.message}`);
+    return;
+  }
   state.currentRoadmapId = result.data.id;
   await loadRoadmapList();
   persistState();
@@ -156,7 +164,6 @@ export function subscribeRealtime(roadmapId) {
     .channel(`roadmap:${roadmapId}`)
     .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'roadmaps', filter: `id=eq.${roadmapId}` },
       (payload) => {
-        if (payload.new.updated_at === payload.old.updated_at) return;
         state.workstreams = payload.new.workstreams;
         state.features    = payload.new.features;
         state.nextId      = payload.new.next_id;

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,37 @@
+const DEFAULT_CONFIG = {
+  months: ["FEB","MAR","APR","MAY","JUN","JUL","AUG","SEP","OCT","NOV","DEC","JAN"],
+  currentMonth: 2,
+  colWidth: 60,
+  labelWidth: 160,
+  releases: [
+    { label: "Winter 26", start: 0, end: 2,  bg: "#DDE3F0" },
+    { label: "Spring 26",  start: 3, end: 5,  bg: "#C8E6C9" },
+    { label: "Summer 26", start: 6, end: 8,  bg: "#FFE0B2" },
+    { label: "Winter 27", start: 9, end: 11, bg: "#E1BEE7" },
+  ],
+  statuses: [
+    { id: "deployed",   label: "Deployed",        color: "#2E7D32", fill: "#C8E6C9" },
+    { id: "ready",      label: "Ready to deploy",  color: "#1565C0", fill: "#BBDEFB" },
+    { id: "poc",        label: "POC / Pilot",      color: "#E65100", fill: "#FFE0B2" },
+    { id: "exploring",  label: "Exploring",        color: "#6A1B9A", fill: "#E1BEE7" },
+    { id: "reqs",       label: "Reqs gathering",   color: "#AD1457", fill: "#FCE4EC" },
+    { id: "notstarted", label: "Not started",      color: "#546E7A", fill: "#ECEFF1" },
+  ],
+};
+
+let _config = null;
+
+export async function initConfig() {
+  try {
+    const res = await fetch(import.meta.env.BASE_URL + 'config.json');
+    if (res.ok) {
+      _config = await res.json();
+      return;
+    }
+  } catch (_) {}
+  _config = structuredClone(DEFAULT_CONFIG);
+}
+
+export function getConfig() {
+  return _config || DEFAULT_CONFIG;
+}

--- a/src/export/exportGoogleSlides.js
+++ b/src/export/exportGoogleSlides.js
@@ -1,0 +1,285 @@
+import { getConfig } from '../config.js';
+import { state } from '../state.js';
+
+const SCOPES = 'https://www.googleapis.com/auth/presentations https://www.googleapis.com/auth/drive.file';
+
+let tokenClient = null;
+let gapiLoaded = false;
+let gisLoaded = false;
+
+function loadScript(src) {
+  return new Promise((resolve, reject) => {
+    if (document.querySelector(`script[src="${src}"]`)) { resolve(); return; }
+    const s = document.createElement('script');
+    s.src = src;
+    s.onload = resolve;
+    s.onerror = reject;
+    document.head.appendChild(s);
+  });
+}
+
+async function ensureLibsLoaded() {
+  if (!gapiLoaded) {
+    await loadScript('https://apis.google.com/js/api.js');
+    await new Promise((resolve) => window.gapi.load('client', resolve));
+    await window.gapi.client.init({});
+    await window.gapi.client.load('https://slides.googleapis.com/$discovery/rest?version=v1');
+    await window.gapi.client.load('https://www.googleapis.com/discovery/v1/apis/drive/v3/rest');
+    gapiLoaded = true;
+  }
+  if (!gisLoaded) {
+    await loadScript('https://accounts.google.com/gsi/client');
+    gisLoaded = true;
+  }
+}
+
+function getAccessToken() {
+  const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+  if (!clientId) {
+    throw new Error('VITE_GOOGLE_CLIENT_ID is not set. See .env.example for setup instructions.');
+  }
+  return new Promise((resolve, reject) => {
+    tokenClient = window.google.accounts.oauth2.initTokenClient({
+      client_id: clientId,
+      scope: SCOPES,
+      callback: (resp) => {
+        if (resp.error) reject(new Error(resp.error));
+        else resolve(resp.access_token);
+      },
+    });
+    tokenClient.requestAccessToken({ prompt: 'consent' });
+  });
+}
+
+function hexNoHash(color) {
+  return color.replace('#', '');
+}
+
+function rgbFromHex(hex) {
+  const h = hexNoHash(hex);
+  return {
+    red:   parseInt(h.slice(0,2), 16) / 255,
+    green: parseInt(h.slice(2,4), 16) / 255,
+    blue:  parseInt(h.slice(4,6), 16) / 255,
+  };
+}
+
+function ptToEmu(pt) { return Math.round(pt * 12700); }
+function inToEmu(inches) { return Math.round(inches * 914400); }
+
+function makeRect(x, y, w, h) {
+  return {
+    size: { width: { emu: inToEmu(w) }, height: { emu: inToEmu(h) } },
+    transform: { translateX: inToEmu(x), translateY: inToEmu(y), scaleX: 1, scaleY: 1, unit: 'EMU' },
+  };
+}
+
+function shapeRequest(objectId, x, y, w, h, fillHex, strokeHex) {
+  const requests = [
+    {
+      createShape: {
+        objectId,
+        shapeType: 'RECTANGLE',
+        elementProperties: { pageObjectId: '{{PAGE_ID}}', ...makeRect(x, y, w, h) },
+      },
+    },
+    {
+      updateShapeProperties: {
+        objectId,
+        shapeProperties: {
+          shapeBackgroundFill: { solidFill: { color: { rgbColor: rgbFromHex(fillHex) } } },
+          outline: strokeHex
+            ? { outlineFill: { solidFill: { color: { rgbColor: rgbFromHex(strokeHex) } } }, weight: { magnitude: 9525, unit: 'EMU' } }
+            : { dashStyle: 'NONE' },
+        },
+        fields: 'shapeBackgroundFill,outline',
+      },
+    },
+  ];
+  return requests;
+}
+
+function textRequest(objectId, text, x, y, w, h, opts = {}) {
+  const { fontSize = 7, bold = false, colorHex = '555555', align = 'LEFT' } = opts;
+  return [
+    {
+      createShape: {
+        objectId,
+        shapeType: 'TEXT_BOX',
+        elementProperties: { pageObjectId: '{{PAGE_ID}}', ...makeRect(x, y, w, h) },
+      },
+    },
+    {
+      insertText: { objectId, text },
+    },
+    {
+      updateTextStyle: {
+        objectId,
+        style: {
+          fontSize: { magnitude: fontSize, unit: 'PT' },
+          bold,
+          foregroundColor: { opaqueColor: { rgbColor: rgbFromHex(colorHex) } },
+        },
+        fields: 'fontSize,bold,foregroundColor',
+      },
+    },
+    {
+      updateParagraphStyle: {
+        objectId,
+        style: { alignment: align },
+        fields: 'alignment',
+      },
+    },
+  ];
+}
+
+async function buildRequests(cfg, pageId) {
+  const LABEL_COL_W = 1.4;
+  const MONTH_W     = (10 - LABEL_COL_W) / 12;
+  const ROW_H       = 0.28;
+  const RELEASE_Y   = 0.4;
+  const MONTHS_Y    = 0.65;
+  const BODY_Y      = 0.9;
+  const LEGEND_Y    = 5.2;
+
+  let requests = [];
+  let uid = 0;
+  const id = (prefix) => `${prefix}_${uid++}`;
+
+  const applyPageId = (reqs) =>
+    reqs.map(r => JSON.parse(JSON.stringify(r).replace(/\{\{PAGE_ID\}\}/g, pageId)));
+
+  // Title
+  const titleName = document.getElementById('roadmap-name')?.value || state.currentRoadmapName || 'Deployment Roadmap';
+  requests.push(...applyPageId(textRequest(id('title'), titleName, 0.1, 0, 9.8, RELEASE_Y, { fontSize: 16, bold: true, colorHex: '232F3E' })));
+
+  // Release bands
+  cfg.releases.forEach(rel => {
+    const x = LABEL_COL_W + rel.start * MONTH_W;
+    const w = (rel.end - rel.start + 1) * MONTH_W;
+    requests.push(...applyPageId(shapeRequest(id('rel'), x, RELEASE_Y, w, 0.25, hexNoHash(rel.bg), 'CCCCCC')));
+    requests.push(...applyPageId(textRequest(id('relt'), rel.label, x, RELEASE_Y, w, 0.25, { fontSize: 7, colorHex: '555555', align: 'CENTER' })));
+  });
+
+  // Month headers
+  requests.push(...applyPageId(textRequest(id('wfhdr'), 'Workstream / Feature', 0, MONTHS_Y, LABEL_COL_W, 0.25, { fontSize: 7, bold: true, colorHex: '444444' })));
+  cfg.months.forEach((m, i) => {
+    const x = LABEL_COL_W + i * MONTH_W;
+    const isCurrent = i === cfg.currentMonth;
+    requests.push(...applyPageId(shapeRequest(id('mhdr'), x, MONTHS_Y, MONTH_W, 0.25, isCurrent ? 'FF9900' : 'F5F5F5', 'DDDDDD')));
+    requests.push(...applyPageId(textRequest(id('mhdrt'), m, x, MONTHS_Y, MONTH_W, 0.25, { fontSize: 7, colorHex: isCurrent ? 'FFFFFF' : '666666', bold: isCurrent, align: 'CENTER' })));
+  });
+
+  // Feature rows
+  let currentY = BODY_Y;
+  state.workstreams.forEach(ws => {
+    const wsFeatures = state.features.filter(f => f.ws === ws.id);
+    if (wsFeatures.length === 0 || currentY + ROW_H > LEGEND_Y - 0.1) return;
+
+    requests.push(...applyPageId(shapeRequest(id('wsrow'), 0, currentY, 10, ROW_H, 'F0F0F0', 'DDDDDD')));
+    requests.push(...applyPageId(textRequest(id('wsname'), ws.name, 0.26, currentY, LABEL_COL_W - 0.3, ROW_H, { fontSize: 8, bold: true, colorHex: '333333' })));
+    currentY += ROW_H;
+
+    wsFeatures.forEach(f => {
+      if (currentY + ROW_H > LEGEND_Y - 0.1) return;
+      const st = cfg.statuses.find(s => s.id === f.status) || cfg.statuses[cfg.statuses.length - 1];
+
+      requests.push(...applyPageId(textRequest(id('fname'), f.name, 0.05, currentY, LABEL_COL_W - 0.1, ROW_H, { fontSize: 7, colorHex: '555555' })));
+
+      const barX = LABEL_COL_W + f.start * MONTH_W + 0.03;
+      const barW = Math.max((f.end - f.start + 1) * MONTH_W - 0.06, 0.1);
+      requests.push(...applyPageId(shapeRequest(id('bar'), barX, currentY + 0.04, barW, ROW_H - 0.08, hexNoHash(st.fill), hexNoHash(st.color))));
+      requests.push(...applyPageId(textRequest(id('bart'), f.name, barX + 0.04, currentY + 0.04, barW - 0.08, ROW_H - 0.08, { fontSize: 6, colorHex: hexNoHash(st.color) })));
+
+      currentY += ROW_H;
+    });
+  });
+
+  // Legend
+  let legendX = 0.1;
+  cfg.statuses.forEach(s => {
+    if (legendX + 1.55 > 10) return;
+    requests.push(...applyPageId(shapeRequest(id('ldot'), legendX, LEGEND_Y + 0.04, 0.1, 0.1, hexNoHash(s.color), hexNoHash(s.color))));
+    requests.push(...applyPageId(textRequest(id('llbl'), s.label, legendX + 0.15, LEGEND_Y, 1.35, 0.2, { fontSize: 7, colorHex: '555555' })));
+    legendX += 1.55;
+  });
+
+  return requests;
+}
+
+export async function exportToGoogleSlides() {
+  const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+  if (!clientId) {
+    alert('Google Slides export is not configured yet.\n\nTo enable it:\n1. Create a GCP project with the Slides API enabled\n2. Add your OAuth Client ID to a .env file as VITE_GOOGLE_CLIENT_ID\n\nSee .env.example for details.');
+    return;
+  }
+
+  const btn = document.getElementById('btn-google-slides');
+  if (btn) { btn.disabled = true; btn.textContent = 'Exporting…'; }
+
+  try {
+    await ensureLibsLoaded();
+    await getAccessToken();
+
+    const cfg = getConfig();
+    const titleName = document.getElementById('roadmap-name')?.value || state.currentRoadmapName || 'Deployment Roadmap';
+
+    // Create a blank presentation
+    const createResp = await window.gapi.client.slides.presentations.create({ title: titleName });
+    const presentation = createResp.result;
+    const presentationId = presentation.presentationId;
+    const pageId = presentation.slides[0].objectId;
+
+    // Set slide size to widescreen (10" x 5.63")
+    await window.gapi.client.slides.presentations.batchUpdate({
+      presentationId,
+      resource: {
+        requests: [{
+          updatePageProperties: {
+            objectId: pageId,
+            pageProperties: {
+              pageSize: {
+                width:  { magnitude: inToEmu(10),   unit: 'EMU' },
+                height: { magnitude: inToEmu(5.63),  unit: 'EMU' },
+              },
+            },
+            fields: 'pageSize',
+          },
+        }],
+      },
+    });
+
+    // Delete the default placeholder text boxes
+    const placeholders = presentation.slides[0].pageElements || [];
+    if (placeholders.length > 0) {
+      await window.gapi.client.slides.presentations.batchUpdate({
+        presentationId,
+        resource: {
+          requests: placeholders.map(el => ({ deleteObject: { objectId: el.objectId } })),
+        },
+      });
+    }
+
+    // Build and apply all content requests
+    const requests = await buildRequests(cfg, pageId);
+    if (requests.length > 0) {
+      await window.gapi.client.slides.presentations.batchUpdate({
+        presentationId,
+        resource: { requests },
+      });
+    }
+
+    // Share with "anyone with link can view"
+    await window.gapi.client.drive.permissions.create({
+      fileId: presentationId,
+      resource: { role: 'reader', type: 'anyone' },
+    });
+
+    window.open(`https://docs.google.com/presentation/d/${presentationId}/edit`, '_blank');
+  } catch (err) {
+    console.error('Google Slides export failed:', err);
+    alert(`Export failed: ${err.message}`);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = 'Export to Google Slides'; }
+  }
+}

--- a/src/export/exportPptx.js
+++ b/src/export/exportPptx.js
@@ -1,0 +1,156 @@
+import PptxGenJS from 'pptxgenjs';
+import { getConfig } from '../config.js';
+import { state } from '../state.js';
+
+const SLIDE_W      = 10;
+const SLIDE_H      = 5.63;
+const LABEL_COL_W  = 1.4;
+const MONTH_W      = (SLIDE_W - LABEL_COL_W) / 12;
+const ROW_H        = 0.28;
+const RELEASE_Y    = 0.4;
+const MONTHS_Y     = 0.65;
+const BODY_START_Y = 0.9;
+const LEGEND_Y     = 5.2;
+const OVERFLOW_Y   = 5.05;
+
+function hex(color) {
+  return color.replace('#', '');
+}
+
+function buildSlide(prs, cfg, workstreamsSubset, featuresSubset) {
+  const slide = prs.addSlide();
+
+  // Title
+  const name = document.getElementById('roadmap-name')?.value || state.currentRoadmapName || 'Deployment Roadmap';
+  slide.addText(name, {
+    x: 0.1, y: 0, w: SLIDE_W - 0.2, h: RELEASE_Y,
+    fontSize: 16, bold: true, color: '232F3E', valign: 'middle',
+  });
+
+  // Release bands
+  cfg.releases.forEach(rel => {
+    const x = LABEL_COL_W + rel.start * MONTH_W;
+    const w = (rel.end - rel.start + 1) * MONTH_W;
+    slide.addShape(prs.ShapeType.rect, {
+      x, y: RELEASE_Y, w, h: 0.25,
+      fill: { color: hex(rel.bg) },
+      line: { color: 'CCCCCC', width: 0.5 },
+    });
+    slide.addText(rel.label, {
+      x, y: RELEASE_Y, w, h: 0.25,
+      fontSize: 7, align: 'center', color: '555555',
+    });
+  });
+
+  // Month headers
+  slide.addText('Workstream / Feature', {
+    x: 0, y: MONTHS_Y, w: LABEL_COL_W, h: 0.25,
+    fontSize: 7, bold: true, color: '444444', valign: 'middle',
+  });
+  cfg.months.forEach((m, i) => {
+    const x = LABEL_COL_W + i * MONTH_W;
+    const isCurrent = i === cfg.currentMonth;
+    slide.addShape(prs.ShapeType.rect, {
+      x, y: MONTHS_Y, w: MONTH_W, h: 0.25,
+      fill: { color: isCurrent ? 'FF9900' : 'F5F5F5' },
+      line: { color: 'DDDDDD', width: 0.5 },
+    });
+    slide.addText(m, {
+      x, y: MONTHS_Y, w: MONTH_W, h: 0.25,
+      fontSize: 7, align: 'center',
+      color: isCurrent ? 'FFFFFF' : '666666',
+      bold: isCurrent,
+    });
+  });
+
+  let currentY = BODY_START_Y;
+  const overflowMap = new Map();
+
+  workstreamsSubset.forEach(ws => {
+    const wsFeatures = featuresSubset.filter(f => f.ws === ws.id);
+    if (wsFeatures.length === 0) return;
+
+    // WS header row — check if it fits
+    if (currentY + ROW_H > OVERFLOW_Y) {
+      overflowMap.set(ws, wsFeatures);
+      return;
+    }
+    slide.addShape(prs.ShapeType.rect, {
+      x: 0, y: currentY, w: SLIDE_W, h: ROW_H,
+      fill: { color: 'F0F0F0' },
+      line: { color: 'DDDDDD', width: 0.5 },
+    });
+    slide.addShape(prs.ShapeType.ellipse, {
+      x: 0.08, y: currentY + (ROW_H - 0.12) / 2, w: 0.12, h: 0.12,
+      fill: { color: hex(ws.color) },
+      line: { color: hex(ws.color), width: 0 },
+    });
+    slide.addText(ws.name, {
+      x: 0.26, y: currentY, w: LABEL_COL_W - 0.3, h: ROW_H,
+      fontSize: 8, bold: true, color: '333333', valign: 'middle',
+    });
+    currentY += ROW_H;
+
+    const overflowFeatures = [];
+    wsFeatures.forEach(f => {
+      if (currentY + ROW_H > OVERFLOW_Y) {
+        overflowFeatures.push(f);
+        return;
+      }
+      const st = cfg.statuses.find(s => s.id === f.status) || cfg.statuses[cfg.statuses.length - 1];
+
+      slide.addText(f.name, {
+        x: 0.05, y: currentY, w: LABEL_COL_W - 0.1, h: ROW_H,
+        fontSize: 7, color: '555555', valign: 'middle',
+      });
+
+      const barX = LABEL_COL_W + f.start * MONTH_W + 0.03;
+      const barW = Math.max((f.end - f.start + 1) * MONTH_W - 0.06, 0.1);
+      slide.addShape(prs.ShapeType.rect, {
+        x: barX, y: currentY + 0.04, w: barW, h: ROW_H - 0.08,
+        fill: { color: hex(st.fill) },
+        line: { color: hex(st.color), width: 1 },
+      });
+      slide.addText(f.name, {
+        x: barX + 0.04, y: currentY + 0.04, w: barW - 0.08, h: ROW_H - 0.08,
+        fontSize: 6, color: hex(st.color), valign: 'middle',
+      });
+
+      currentY += ROW_H;
+    });
+
+    if (overflowFeatures.length > 0) overflowMap.set(ws, overflowFeatures);
+  });
+
+  // Legend strip
+  let legendX = 0.1;
+  cfg.statuses.forEach(s => {
+    if (legendX + 1.55 > SLIDE_W) return;
+    slide.addShape(prs.ShapeType.ellipse, {
+      x: legendX, y: LEGEND_Y + 0.04, w: 0.1, h: 0.1,
+      fill: { color: hex(s.color) },
+      line: { color: hex(s.color), width: 0 },
+    });
+    slide.addText(s.label, {
+      x: legendX + 0.15, y: LEGEND_Y, w: 1.35, h: 0.2,
+      fontSize: 7, color: '555555',
+    });
+    legendX += 1.55;
+  });
+
+  // Recurse for overflow
+  if (overflowMap.size > 0) {
+    buildSlide(prs, cfg, [...overflowMap.keys()], [...overflowMap.values()].flat());
+  }
+}
+
+export function exportToPptx() {
+  const cfg = getConfig();
+  const prs = new PptxGenJS();
+  prs.layout = 'LAYOUT_WIDE';
+
+  buildSlide(prs, cfg, state.workstreams, state.features);
+
+  const name = document.getElementById('roadmap-name')?.value || state.currentRoadmapName || 'roadmap';
+  prs.writeFile({ fileName: `${name.replace(/[^a-z0-9]/gi, '-').toLowerCase()}-roadmap.pptx` });
+}

--- a/src/filters.js
+++ b/src/filters.js
@@ -1,0 +1,21 @@
+import { getConfig } from './config.js';
+import { state } from './state.js';
+
+export function populateFilters() {
+  const cfg = getConfig();
+  document.getElementById('filterWs').innerHTML =
+    '<option value="">All workstreams</option>' +
+    state.workstreams.map(w => `<option value="${w.id}">${w.name}</option>`).join('');
+  document.getElementById('filterStatus').innerHTML =
+    '<option value="">All statuses</option>' +
+    cfg.statuses.map(s => `<option value="${s.id}">${s.label}</option>`).join('');
+}
+
+export function renderLegend() {
+  const cfg = getConfig();
+  document.getElementById('legend').innerHTML = cfg.statuses.map(s =>
+    `<div class="legend-item">
+      <div class="legend-dot" style="background:${s.color}"></div>${s.label}
+    </div>`
+  ).join('');
+}

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -1,0 +1,68 @@
+import { getConfig } from './config.js';
+import { state, persistState } from './state.js';
+import { render } from './render.js';
+
+let resizing = null;
+let dragSrc = null;
+
+export function cellClick(fid, mi) {
+  const f = state.features.find(x => x.id === fid);
+  if (!f) return;
+  if (mi < f.start)    { f.start = mi; render(); persistState(); }
+  else if (mi > f.end) { f.end   = mi; render(); persistState(); }
+}
+
+export function startResize(e, fid, side) {
+  e.stopPropagation();
+  e.preventDefault();
+  resizing = { fid, side, startX: e.clientX, orig: { ...state.features.find(x => x.id === fid) } };
+  document.addEventListener('mousemove', doResize);
+  document.addEventListener('mouseup', stopResize);
+}
+
+export function doResize(e) {
+  if (!resizing) return;
+  const cfg = getConfig();
+  const dx = e.clientX - resizing.startX;
+  const dMonths = Math.round(dx / cfg.colWidth);
+  const f = state.features.find(x => x.id === resizing.fid);
+  if (!f) return;
+  if (resizing.side === 'r') {
+    f.end   = Math.min(cfg.months.length - 1, Math.max(f.start, resizing.orig.end   + dMonths));
+  } else {
+    f.start = Math.max(0, Math.min(f.end, resizing.orig.start + dMonths));
+  }
+  render();
+}
+
+export function stopResize() {
+  if (!resizing) return;
+  persistState();
+  resizing = null;
+  document.removeEventListener('mousemove', doResize);
+  document.removeEventListener('mouseup', stopResize);
+}
+
+export function dragStart(e, fid) {
+  dragSrc = fid;
+  e.dataTransfer.effectAllowed = 'move';
+}
+
+export function dragOver(e, fid) {
+  e.preventDefault();
+  if (fid !== dragSrc) e.currentTarget.classList.add('dragging-over');
+}
+
+export function dropOn(e, fid) {
+  e.currentTarget.classList.remove('dragging-over');
+  if (!dragSrc || dragSrc === fid) return;
+  const src = state.features.find(x => x.id === dragSrc);
+  const tgt = state.features.find(x => x.id === fid);
+  if (!src || !tgt || src.ws !== tgt.ws) return;
+  const si = state.features.indexOf(src);
+  const ti = state.features.indexOf(tgt);
+  state.features.splice(si, 1);
+  state.features.splice(ti, 0, src);
+  render();
+  persistState();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,66 @@
+import './styles/main.css';
+import { initConfig } from './config.js';
+import { state, initState, persistState, exportStateAsJson, importStateFromJson } from './state.js';
+import { render } from './render.js';
+import { populateFilters, renderLegend } from './filters.js';
+import {
+  initModals, openAddFeature, openEdit, openAddWorkstream, openEditWorkstream,
+  saveFeature, deleteFeature, closeModal, saveWorkstream, deleteWorkstream,
+  pickStart, pickEnd,
+} from './modals.js';
+import {
+  startResize, doResize, stopResize, dragStart, dragOver, dropOn, cellClick,
+} from './interactions.js';
+import { exportToPptx } from './export/exportPptx.js';
+import { exportToGoogleSlides } from './export/exportGoogleSlides.js';
+import {
+  initAuth, isConfigured, showSignIn, signOut,
+  loadRoadmap, saveRoadmap, newRoadmap, subscribeRealtime,
+} from './auth.js';
+
+// Expose all functions called from inline onclick handlers in render()
+Object.assign(window, {
+  render, openAddFeature, openEdit, openAddWorkstream, openEditWorkstream,
+  saveFeature, deleteFeature, closeModal, saveWorkstream, deleteWorkstream,
+  pickStart, pickEnd, startResize, doResize, stopResize, dragStart, dragOver,
+  dropOn, cellClick, exportToPptx, exportToGoogleSlides, exportStateAsJson,
+  showSignIn, signOut, saveRoadmap, newRoadmap,
+  handleRoadmapSelect: async (e) => {
+    const id = e.target.value;
+    if (id) {
+      await loadRoadmap(id);
+      subscribeRealtime(id);
+    } else {
+      await newRoadmap();
+    }
+  },
+  handleJsonImport: (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    importStateFromJson(file)
+      .then(() => { populateFilters(); render(); })
+      .catch(err => alert(`Import failed: ${err.message}`));
+  },
+});
+
+async function init() {
+  await initConfig();
+  initState();
+  await initAuth();
+  initModals();
+  populateFilters();
+  renderLegend();
+  render();
+
+  // Wire up roadmap name input
+  const nameEl = document.getElementById('roadmap-name');
+  if (nameEl) {
+    nameEl.value = state.currentRoadmapName;
+    nameEl.addEventListener('change', () => {
+      state.currentRoadmapName = nameEl.value.trim() || 'My Roadmap';
+      persistState();
+    });
+  }
+}
+
+init();

--- a/src/modals.js
+++ b/src/modals.js
@@ -1,0 +1,152 @@
+import { getConfig } from './config.js';
+import { state, persistState } from './state.js';
+import { render } from './render.js';
+import { populateFilters } from './filters.js';
+
+let selStart = 0, selEnd = 0, editingId = null;
+let editingWsId = null;
+
+export function buildMonthBtns(containerId, selected, onSelectName) {
+  const cfg = getConfig();
+  document.getElementById(containerId).innerHTML = cfg.months.map((m, i) =>
+    `<div class="month-btn${i === selected ? ' selected' : ''}" onclick="${onSelectName}(${i})">${m}</div>`
+  ).join('');
+}
+
+export function pickStart(i) {
+  selStart = i;
+  if (selEnd < i) selEnd = i;
+  buildMonthBtns('start-months', selStart, 'pickStart');
+  buildMonthBtns('end-months',   selEnd,   'pickEnd');
+}
+
+export function pickEnd(i) {
+  selEnd = i;
+  if (selStart > i) selStart = i;
+  buildMonthBtns('start-months', selStart, 'pickStart');
+  buildMonthBtns('end-months',   selEnd,   'pickEnd');
+}
+
+export function openAddFeature(wsId) {
+  editingId = null;
+  document.getElementById('modal-title').textContent = 'Add feature';
+  document.getElementById('f-name').value = '';
+  document.getElementById('delete-btn').style.display = 'none';
+  populateWsSelect(wsId || state.workstreams[0]?.id || '');
+  populateStatusSelect('notstarted');
+  selStart = 0; selEnd = 0;
+  buildMonthBtns('start-months', 0, 'pickStart');
+  buildMonthBtns('end-months',   0, 'pickEnd');
+  document.getElementById('modal-bg').classList.add('open');
+}
+
+export function openEdit(fid) {
+  const f = state.features.find(x => x.id === fid);
+  if (!f) return;
+  editingId = fid;
+  document.getElementById('modal-title').textContent = 'Edit feature';
+  document.getElementById('f-name').value = f.name;
+  document.getElementById('delete-btn').style.display = 'block';
+  populateWsSelect(f.ws);
+  populateStatusSelect(f.status);
+  selStart = f.start; selEnd = f.end;
+  buildMonthBtns('start-months', selStart, 'pickStart');
+  buildMonthBtns('end-months',   selEnd,   'pickEnd');
+  document.getElementById('modal-bg').classList.add('open');
+}
+
+function populateWsSelect(selected) {
+  document.getElementById('f-ws').innerHTML = state.workstreams.map(w =>
+    `<option value="${w.id}"${w.id === selected ? ' selected' : ''}>${w.name}</option>`
+  ).join('');
+}
+
+function populateStatusSelect(selected) {
+  const cfg = getConfig();
+  document.getElementById('f-status').innerHTML = cfg.statuses.map(s =>
+    `<option value="${s.id}"${s.id === selected ? ' selected' : ''}>${s.label}</option>`
+  ).join('');
+}
+
+export function saveFeature() {
+  const name   = document.getElementById('f-name').value.trim();
+  const ws     = document.getElementById('f-ws').value;
+  const status = document.getElementById('f-status').value;
+  if (!name) return;
+  if (editingId != null) {
+    Object.assign(state.features.find(x => x.id === editingId), { name, ws, status, start: selStart, end: selEnd });
+  } else {
+    state.features.push({ id: state.nextId++, name, ws, status, start: selStart, end: selEnd });
+  }
+  closeModal();
+  render();
+  persistState();
+}
+
+export function deleteFeature() {
+  state.features = state.features.filter(x => x.id !== editingId);
+  closeModal();
+  render();
+  persistState();
+}
+
+export function closeModal() {
+  document.getElementById('modal-bg').classList.remove('open');
+  editingId = null;
+}
+
+export function openAddWorkstream() {
+  editingWsId = null;
+  document.getElementById('ws-modal-title').textContent = 'Add workstream';
+  document.getElementById('ws-name-input').value = '';
+  document.getElementById('ws-delete-btn').style.display = 'none';
+  document.getElementById('ws-modal-bg').classList.add('open');
+}
+
+export function openEditWorkstream(id) {
+  const ws = state.workstreams.find(w => w.id === id);
+  if (!ws) return;
+  editingWsId = id;
+  document.getElementById('ws-modal-title').textContent = 'Edit workstream';
+  document.getElementById('ws-name-input').value = ws.name;
+  document.getElementById('ws-color-input').value = ws.color;
+  document.getElementById('ws-delete-btn').style.display = 'block';
+  document.getElementById('ws-modal-bg').classList.add('open');
+}
+
+export function saveWorkstream() {
+  const name  = document.getElementById('ws-name-input').value.trim();
+  const color = document.getElementById('ws-color-input').value;
+  if (!name) return;
+  if (editingWsId) {
+    const ws = state.workstreams.find(w => w.id === editingWsId);
+    ws.name = name; ws.color = color;
+  } else {
+    state.workstreams.push({ id: name.toLowerCase().replace(/\s+/g, '-'), name, color });
+  }
+  document.getElementById('ws-modal-bg').classList.remove('open');
+  populateFilters();
+  render();
+  persistState();
+}
+
+export function deleteWorkstream() {
+  if (state.features.some(f => f.ws === editingWsId)) {
+    alert('Move or delete all features in this workstream first.');
+    return;
+  }
+  state.workstreams = state.workstreams.filter(w => w.id !== editingWsId);
+  document.getElementById('ws-modal-bg').classList.remove('open');
+  populateFilters();
+  render();
+  persistState();
+}
+
+export function initModals() {
+  document.getElementById('modal-bg').addEventListener('click', function(e) {
+    if (e.target === this) closeModal();
+  });
+  document.getElementById('ws-modal-bg').addEventListener('click', function(e) {
+    if (e.target === this) document.getElementById('ws-modal-bg').classList.remove('open');
+  });
+}

--- a/src/render.js
+++ b/src/render.js
@@ -1,0 +1,94 @@
+import { getConfig } from './config.js';
+import { state } from './state.js';
+
+export function statusFor(id) {
+  const cfg = getConfig();
+  return cfg.statuses.find(s => s.id === id) || cfg.statuses[cfg.statuses.length - 1];
+}
+
+function gridCols() {
+  const cfg = getConfig();
+  return `${cfg.labelWidth}px ${cfg.months.map(() => cfg.colWidth + 'px').join(' ')}`;
+}
+
+export function render() {
+  const cfg = getConfig();
+  const filterWs = document.getElementById('filterWs').value;
+  const filterSt = document.getElementById('filterStatus').value;
+  const g = document.getElementById('gantt');
+  let html = '';
+
+  // Release band header
+  html += `<div class="release-row" style="display:grid;grid-template-columns:${gridCols()}">`;
+  html += `<div class="release-cell"></div>`;
+  cfg.months.forEach((m, i) => {
+    const rel = cfg.releases.find(r => r.start <= i && i <= r.end);
+    if (rel && i === rel.start) {
+      const span = rel.end - rel.start + 1;
+      html += `<div class="release-cell" style="grid-column:span ${span};background:${rel.bg}">${rel.label}</div>`;
+    } else if (!rel) {
+      html += `<div class="release-cell"></div>`;
+    }
+  });
+  html += '</div>';
+
+  // Month header row
+  html += `<div class="gantt-header" style="display:grid;grid-template-columns:${gridCols()}">`;
+  html += `<div class="month-cell" style="text-align:left;padding-left:10px">Workstream / Feature</div>`;
+  cfg.months.forEach((m, i) => {
+    html += `<div class="month-cell${i === cfg.currentMonth ? ' current' : ''}">${m}</div>`;
+  });
+  html += '</div>';
+
+  // One section per workstream
+  state.workstreams.forEach(ws => {
+    if (filterWs && ws.id !== filterWs) return;
+    const wsFeatures = state.features.filter(f => f.ws === ws.id && (!filterSt || f.status === filterSt));
+
+    html += `<div class="ws-section">`;
+    html += `<div class="ws-header">
+      <div class="ws-dot" style="background:${ws.color}"></div>
+      <div class="ws-name">${ws.name}</div>
+      <div class="ws-actions">
+        <button onclick="openAddFeature('${ws.id}')">+ feature</button>
+        <button onclick="openEditWorkstream('${ws.id}')">edit</button>
+      </div>
+    </div>`;
+
+    wsFeatures.forEach(f => {
+      const st = statusFor(f.status);
+      html += `<div class="feature-row" style="display:grid;grid-template-columns:${gridCols()}"
+        draggable="true"
+        ondragstart="dragStart(event,${f.id})"
+        ondragover="dragOver(event,${f.id})"
+        ondrop="dropOn(event,${f.id})"
+        ondragleave="this.classList.remove('dragging-over')">`;
+
+      html += `<div class="feature-label">
+        <span class="drag-handle">⠿</span>
+        <span onclick="openEdit(${f.id})" style="cursor:pointer">${f.name}</span>
+      </div>`;
+
+      cfg.months.forEach((_, i) => {
+        const isStart = i === f.start;
+        const totalW = (f.end - f.start + 1) * cfg.colWidth - 8;
+        html += `<div class="cell${i % 2 ? ' alt' : ''}" onclick="cellClick(${f.id},${i})">`;
+        if (isStart) {
+          html += `<div class="bar"
+            style="left:4px;width:${totalW}px;background:${st.fill};border:1px solid ${st.color};color:${st.color}"
+            onclick="openEdit(${f.id});event.stopPropagation()">
+            <div class="bar-resize-l" onmousedown="startResize(event,${f.id},'l')"></div>
+            <span style="overflow:hidden;text-overflow:ellipsis">${f.name}</span>
+            <div class="bar-resize-r" onmousedown="startResize(event,${f.id},'r')"></div>
+          </div>`;
+        }
+        html += '</div>';
+      });
+      html += '</div>';
+    });
+
+    html += '</div>';
+  });
+
+  g.innerHTML = html;
+}

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,81 @@
+const LOCAL_KEY = 'roadmap_local_data';
+
+export const state = {
+  workstreams: [
+    { id: "staffing",   name: "Staffing",   color: "#4A6FA5" },
+    { id: "delivery",   name: "Delivery",   color: "#2E8B57" },
+    { id: "partners",   name: "Partners",   color: "#B8621A" },
+    { id: "operations", name: "Operations", color: "#5B4B8A" },
+  ],
+  features: [
+    { id: 1, ws: "staffing",   name: "Work Planner Contouring", start: 0, end: 2,  status: "deployed" },
+    { id: 2, ws: "staffing",   name: "Resource Forecasting",    start: 2, end: 5,  status: "ready" },
+    { id: 3, ws: "delivery",   name: "Project Billing Rules",   start: 0, end: 3,  status: "poc" },
+    { id: 4, ws: "delivery",   name: "Milestone Tracker",       start: 4, end: 7,  status: "exploring" },
+    { id: 5, ws: "partners",   name: "Partner Portal SSO",      start: 1, end: 4,  status: "reqs" },
+    { id: 6, ws: "operations", name: "Expense Automation",      start: 3, end: 6,  status: "notstarted" },
+  ],
+  nextId: 7,
+  currentRoadmapId: null,
+  currentRoadmapName: 'My Roadmap',
+};
+
+export function initState() {
+  try {
+    const raw = localStorage.getItem(LOCAL_KEY);
+    if (raw) {
+      const saved = JSON.parse(raw);
+      if (saved.workstreams)       state.workstreams       = saved.workstreams;
+      if (saved.features)          state.features          = saved.features;
+      if (saved.nextId)            state.nextId            = saved.nextId;
+      if (saved.currentRoadmapName) state.currentRoadmapName = saved.currentRoadmapName;
+    }
+  } catch (_) {}
+}
+
+export function persistState() {
+  localStorage.setItem(LOCAL_KEY, JSON.stringify({
+    workstreams:       state.workstreams,
+    features:          state.features,
+    nextId:            state.nextId,
+    currentRoadmapName: state.currentRoadmapName,
+  }));
+}
+
+export function exportStateAsJson() {
+  const data = {
+    name: state.currentRoadmapName,
+    workstreams: state.workstreams,
+    features: state.features,
+    nextId: state.nextId,
+    exportedAt: new Date().toISOString(),
+  };
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${state.currentRoadmapName.replace(/[^a-z0-9]/gi, '-')}-roadmap.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function importStateFromJson(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const data = JSON.parse(e.target.result);
+        if (!data.workstreams || !data.features) throw new Error('Invalid roadmap file');
+        state.workstreams       = data.workstreams;
+        state.features          = data.features;
+        state.nextId            = data.nextId || 100;
+        state.currentRoadmapName = data.name || 'Imported Roadmap';
+        persistState();
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    };
+    reader.readAsText(file);
+  });
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,0 +1,84 @@
+:root {
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --color-background-primary: #ffffff;
+  --color-background-secondary: #f8f9fa;
+  --color-background-info: #e8f4fd;
+  --color-background-danger: #ffeaea;
+  --color-text-primary: #1a1a1a;
+  --color-text-secondary: #666666;
+  --color-text-tertiary: #999999;
+  --color-text-danger: #d32f2f;
+  --color-border-secondary: #e0e0e0;
+  --color-border-tertiary: #ebebeb;
+  --color-border-danger: #f5c6cb;
+  --border-radius-md: 5px;
+  --border-radius-lg: 8px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font-sans);
+  padding: 16px 20px;
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+}
+
+.toolbar { display:flex;gap:8px;align-items:center;flex-wrap:wrap;padding:10px 0 10px;border-bottom:0.5px solid var(--color-border-tertiary);margin-bottom:10px }
+.toolbar button { font-size:12px;padding:5px 10px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary);cursor:pointer }
+.toolbar button:hover { background:var(--color-background-secondary) }
+.toolbar button.primary { background:#232F3E;color:#fff;border-color:#232F3E }
+.toolbar button.primary:hover { background:#1a2330 }
+.toolbar select,.toolbar input[type=text] { font-size:12px;padding:4px 8px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary) }
+.gantt-wrap { overflow-x:auto }
+.gantt { min-width:900px;font-size:11px;user-select:none }
+.gantt-header { display:grid;background:var(--color-background-secondary);border-bottom:0.5px solid var(--color-border-tertiary) }
+.month-cell { padding:5px 2px;text-align:center;font-weight:500;font-size:10px;color:var(--color-text-secondary);border-right:0.5px solid var(--color-border-tertiary) }
+.month-cell.current { background:#FF9900;color:#fff;font-weight:500 }
+.release-row { display:grid;border-bottom:0.5px solid var(--color-border-tertiary) }
+.release-cell { padding:3px 4px;text-align:center;font-size:10px;font-weight:500;color:var(--color-text-secondary);border-right:0.5px solid var(--color-border-tertiary) }
+.ws-section { border-bottom:1px solid var(--color-border-secondary) }
+.ws-header { display:flex;align-items:center;gap:6px;padding:6px 8px;background:var(--color-background-secondary);border-bottom:0.5px solid var(--color-border-tertiary);position:sticky;left:0 }
+.ws-dot { width:10px;height:10px;border-radius:50%;flex-shrink:0 }
+.ws-name { font-weight:500;font-size:12px;color:var(--color-text-primary) }
+.ws-actions { margin-left:auto;display:flex;gap:4px }
+.ws-actions button { font-size:10px;padding:2px 7px;border:0.5px solid var(--color-border-tertiary);border-radius:var(--border-radius-md);background:transparent;color:var(--color-text-secondary);cursor:pointer }
+.ws-actions button:hover { background:var(--color-background-secondary) }
+.feature-row { display:grid;align-items:center;min-height:28px;border-bottom:0.5px solid var(--color-border-tertiary) }
+.feature-row:hover { background:var(--color-background-secondary) }
+.feature-row.dragging-over { background:var(--color-background-info);opacity:.7 }
+.feature-label { padding:0 8px;font-size:11px;color:var(--color-text-secondary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:default;display:flex;align-items:center;gap:4px }
+.feature-label .drag-handle { cursor:grab;color:var(--color-text-tertiary);font-size:13px }
+.cell { border-right:0.5px solid var(--color-border-tertiary);height:100%;min-height:28px;position:relative;cursor:pointer }
+.cell.alt { background:rgba(0,0,0,.015) }
+.bar { position:absolute;top:4px;bottom:4px;border-radius:3px;display:flex;align-items:center;padding:0 5px;font-size:10px;font-weight:500;white-space:nowrap;overflow:hidden;cursor:pointer;transition:opacity .1s }
+.bar:hover { opacity:.85;filter:brightness(1.05) }
+.bar .bar-resize-l,.bar .bar-resize-r { position:absolute;top:0;bottom:0;width:6px;cursor:ew-resize;z-index:2 }
+.bar .bar-resize-l { left:0;border-radius:3px 0 0 3px }
+.bar .bar-resize-r { right:0;border-radius:0 3px 3px 0 }
+.legend { display:flex;flex-wrap:wrap;gap:10px;padding:8px 0 4px;align-items:center }
+.legend-item { display:flex;align-items:center;gap:4px;font-size:11px;color:var(--color-text-secondary) }
+.legend-dot { width:9px;height:9px;border-radius:50%;flex-shrink:0 }
+.modal-bg { display:none;position:fixed;inset:0;background:rgba(0,0,0,.4);z-index:100;align-items:center;justify-content:center }
+.modal-bg.open { display:flex }
+.modal { background:var(--color-background-primary);border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-lg);padding:20px;width:360px;max-width:95vw }
+.modal h3 { font-size:15px;font-weight:500;margin-bottom:14px;color:var(--color-text-primary) }
+.form-row { margin-bottom:10px }
+.form-row label { display:block;font-size:11px;color:var(--color-text-secondary);margin-bottom:3px }
+.form-row input,.form-row select { width:100%;font-size:13px;padding:6px 8px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary) }
+.form-row .month-grid { display:grid;grid-template-columns:repeat(6,1fr);gap:4px }
+.month-btn { padding:4px 2px;text-align:center;font-size:10px;border:0.5px solid var(--color-border-tertiary);border-radius:4px;background:var(--color-background-primary);color:var(--color-text-secondary);cursor:pointer }
+.month-btn.selected { background:#232F3E;color:#fff;border-color:#232F3E }
+.modal-actions { display:flex;justify-content:flex-end;gap:8px;margin-top:14px }
+.modal-actions button { font-size:12px;padding:6px 14px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary);cursor:pointer }
+.modal-actions button.save { background:#232F3E;color:#fff;border-color:#232F3E }
+.modal-actions button.danger { background:var(--color-background-danger);color:var(--color-text-danger);border-color:var(--color-border-danger) }
+
+/* Roadmap selector */
+.roadmap-bar { display:flex;align-items:center;gap:8px;padding:8px 0;margin-bottom:4px;font-size:12px;color:var(--color-text-secondary) }
+.roadmap-bar select { font-size:12px;padding:4px 8px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary);min-width:200px }
+.roadmap-bar .roadmap-name-input { font-size:13px;font-weight:500;padding:4px 8px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary);min-width:220px }
+
+/* Auth bar */
+.auth-bar { display:flex;align-items:center;justify-content:flex-end;gap:8px;padding:6px 0;font-size:11px;color:var(--color-text-secondary);border-bottom:0.5px solid var(--color-border-tertiary);margin-bottom:6px }
+.auth-bar button { font-size:11px;padding:3px 10px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary);cursor:pointer }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -23,13 +23,24 @@ create trigger roadmaps_updated_at
   before update on roadmaps
   for each row execute function update_updated_at();
 
--- Row-level security: all authenticated users can read/write all roadmaps
+-- Row-level security: users can only access their own roadmaps
 alter table roadmaps enable row level security;
 
-create policy "Authenticated users can manage roadmaps"
-  on roadmaps for all
-  using (auth.role() = 'authenticated')
-  with check (auth.role() = 'authenticated');
+create policy "Users can read own roadmaps"
+  on roadmaps for select
+  using (created_by = auth.uid());
+
+create policy "Users can insert own roadmaps"
+  on roadmaps for insert
+  with check (created_by = auth.uid());
+
+create policy "Users can update own roadmaps"
+  on roadmaps for update
+  using (created_by = auth.uid());
+
+create policy "Users can delete own roadmaps"
+  on roadmaps for delete
+  using (created_by = auth.uid());
 
 -- Enable Realtime for live sync
 -- Run this separately in the Supabase dashboard:

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,36 @@
+-- Run this in the Supabase SQL editor for your project
+
+create table if not exists roadmaps (
+  id          uuid primary key default gen_random_uuid(),
+  name        text not null,
+  workstreams jsonb not null default '[]',
+  features    jsonb not null default '[]',
+  next_id     int  not null default 1,
+  created_by  uuid references auth.users on delete set null,
+  updated_at  timestamptz default now()
+);
+
+-- Keep updated_at current automatically
+create or replace function update_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger roadmaps_updated_at
+  before update on roadmaps
+  for each row execute function update_updated_at();
+
+-- Row-level security: all authenticated users can read/write all roadmaps
+alter table roadmaps enable row level security;
+
+create policy "Authenticated users can manage roadmaps"
+  on roadmaps for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+-- Enable Realtime for live sync
+-- Run this separately in the Supabase dashboard:
+--   Table Editor → roadmaps → Realtime → Enable

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,3 @@
+export default {
+  base: process.env.NODE_ENV === 'production' ? '/deployment-roadmap-builder/' : '/',
+};


### PR DESCRIPTION
## Summary

- **RLS policies** — replaced the single over-broad `for all` policy (using deprecated `auth.role()`) with four scoped policies (SELECT, INSERT, UPDATE, DELETE), each gated on `created_by = auth.uid()`
- **Ownership on update** — `saveRoadmap` now adds `.eq("created_by", currentUser.id)` to the update query so users cannot overwrite another user's roadmap even if they know its ID
- **Server-authoritative auth** — replaced `getSession()` (reads unverified local storage) with `getUser()` (validates against the Supabase server)
- **Roadmap selector visibility** — dropdown was permanently hidden via `display:none`; `renderRoadmapSelector` now unhides it after login
- **Save error feedback** — save failures now surface an `alert()` instead of silently logging to console
- **Realtime dedup removed** — the fragile `updated_at` string comparison in the realtime handler was removed; all incoming updates now apply correctly
- **CLAUDE.md updated** — documents auth approach, RLS design, migration status, and Realtime setup requirement

## Test plan

- [ ] Sign in via magic link and confirm roadmaps load and the dropdown appears
- [ ] Save a new roadmap and confirm it appears in the selector
- [ ] Confirm a second user account cannot read or modify the first user's roadmaps (RLS enforcement)
- [ ] Trigger a save error (e.g. bad network) and confirm the alert is shown
- [ ] Open the same roadmap in two tabs and confirm realtime sync works

🤖 Generated with [Claude Code](https://claude.com/claude-code)