### PR TITLE
Replace window.prompt() sign-in with a proper modal (closes #2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,25 @@
     </div>
   </div>
 
+  <!-- Sign-in modal -->
+  <div class="modal-bg" id="signin-modal-bg">
+    <div class="modal">
+      <h3>Sign in</h3>
+      <p style="font-size:12px;color:var(--color-text-secondary);margin-bottom:14px">
+        Enter your email address to receive a sign-in link.
+      </p>
+      <div class="form-row">
+        <label>Email address</label>
+        <input type="email" id="signin-email" placeholder="you@example.com" />
+      </div>
+      <div id="signin-message" style="display:none;font-size:12px;padding:8px;border-radius:var(--border-radius-md);margin-bottom:10px"></div>
+      <div class="modal-actions">
+        <button onclick="closeSignInModal()">Cancel</button>
+        <button class="save" id="signin-submit-btn" onclick="submitSignIn()">Send link</button>
+      </div>
+    </div>
+  </div>
+
   <script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/src/auth.js
+++ b/src/auth.js
@@ -2,6 +2,7 @@ import { createClient } from '@supabase/supabase-js';
 import { state, persistState } from './state.js';
 import { render } from './render.js';
 import { populateFilters } from './filters.js';
+import { openSignInModal, closeSignInModal } from './modals.js';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -52,12 +53,31 @@ function updateAuthBar() {
   }
 }
 
-export async function showSignIn() {
-  const email = prompt('Enter your email address to receive a sign-in link:');
+export function showSignIn() {
+  openSignInModal();
+}
+
+export async function submitSignIn() {
+  const email = document.getElementById('signin-email')?.value?.trim();
+  const msgEl = document.getElementById('signin-message');
+  const btnEl = document.getElementById('signin-submit-btn');
   if (!email || !supabase) return;
+
+  btnEl.disabled = true;
+  msgEl.style.display = 'none';
+
   const { error } = await supabase.auth.signInWithOtp({ email });
-  if (error) alert(`Sign in failed: ${error.message}`);
-  else alert(`Check your email (${email}) for a sign-in link.`);
+
+  if (error) {
+    msgEl.textContent = `Error: ${error.message}`;
+    msgEl.style.cssText = 'display:block;font-size:12px;padding:8px;border-radius:var(--border-radius-md);margin-bottom:10px;background:var(--color-background-danger);color:var(--color-text-danger)';
+    btnEl.disabled = false;
+  } else {
+    msgEl.textContent = `Check your inbox — a sign-in link has been sent to ${email}.`;
+    msgEl.style.cssText = 'display:block;font-size:12px;padding:8px;border-radius:var(--border-radius-md);margin-bottom:10px;background:#e8f5e9;color:#2E7D32';
+    btnEl.disabled = true;
+    setTimeout(closeSignInModal, 4000);
+  }
 }
 
 export async function signOut() {

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import { populateFilters, renderLegend } from './filters.js';
 import {
   initModals, openAddFeature, openEdit, openAddWorkstream, openEditWorkstream,
   saveFeature, deleteFeature, closeModal, saveWorkstream, deleteWorkstream,
-  pickStart, pickEnd,
+  pickStart, pickEnd, openSignInModal, closeSignInModal,
 } from './modals.js';
 import {
   startResize, doResize, stopResize,
@@ -15,7 +15,7 @@ import {
 import { exportToPptx } from './export/exportPptx.js';
 import { exportToGoogleSlides } from './export/exportGoogleSlides.js';
 import {
-  initAuth, isConfigured, showSignIn, signOut,
+  initAuth, isConfigured, showSignIn, signOut, submitSignIn,
   loadRoadmap, saveRoadmap, newRoadmap, subscribeRealtime,
 } from './auth.js';
 
@@ -26,7 +26,8 @@ Object.assign(window, {
   pickStart, pickEnd, startResize, doResize, stopResize,
   dragStart, dragOver, dragEnter, dragLeave, dragEnd, dropOn, cellClick,
   exportToPptx, exportToGoogleSlides, exportStateAsJson,
-  showSignIn, signOut, saveRoadmap, newRoadmap,
+  showSignIn, signOut, submitSignIn, openSignInModal, closeSignInModal,
+  saveRoadmap, newRoadmap,
   handleRoadmapSelect: async (e) => {
     const id = e.target.value;
     if (id) {

--- a/src/modals.js
+++ b/src/modals.js
@@ -33,7 +33,7 @@ export function openAddFeature(wsId) {
   document.getElementById('f-name').value = '';
   document.getElementById('delete-btn').style.display = 'none';
   populateWsSelect(wsId || state.workstreams[0]?.id || '');
-  populateStatusSelect('notstarted');
+  populateStatusSelect('not-started');
   selStart = 0; selEnd = 0;
   buildMonthBtns('start-months', 0, 'pickStart');
   buildMonthBtns('end-months',   0, 'pickEnd');
@@ -142,11 +142,31 @@ export function deleteWorkstream() {
   persistState();
 }
 
+export function openSignInModal() {
+  document.getElementById('signin-email').value = '';
+  const msg = document.getElementById('signin-message');
+  msg.style.display = 'none';
+  msg.textContent = '';
+  document.getElementById('signin-submit-btn').disabled = false;
+  document.getElementById('signin-modal-bg').classList.add('open');
+  setTimeout(() => document.getElementById('signin-email').focus(), 50);
+}
+
+export function closeSignInModal() {
+  document.getElementById('signin-modal-bg').classList.remove('open');
+}
+
 export function initModals() {
   document.getElementById('modal-bg').addEventListener('click', function(e) {
     if (e.target === this) closeModal();
   });
   document.getElementById('ws-modal-bg').addEventListener('click', function(e) {
     if (e.target === this) document.getElementById('ws-modal-bg').classList.remove('open');
+  });
+  document.getElementById('signin-modal-bg').addEventListener('click', function(e) {
+    if (e.target === this) closeSignInModal();
+  });
+  document.getElementById('signin-email').addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') window.submitSignIn();
   });
 }


### PR DESCRIPTION
## Summary

- Adds a sign-in modal with email input, inline success/error messaging, and submit button disabled after send to prevent double-sends
- Modal closes on backdrop click and Enter key
- On success: shows green confirmation and auto-closes after 4s
- On error: shows red inline message and re-enables submit
- Fixes `populateStatusSelect` default from old `notstarted` to `not-started`

## Test plan
- [ ] Click Sign in — modal appears (no browser prompt)
- [ ] Enter email and click Send link — success message appears, modal closes after 4s
- [ ] Enter bad email — error message appears inline, button re-enables
- [ ] Click backdrop — modal closes
- [ ] Press Enter in email field — submits the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)