### PR TITLE
Add loading and saving indicators for async operations (closes #3)

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,8 @@
     <select id="roadmap-select" onchange="handleRoadmapSelect(event)" style="display:none">
       <option value="">— New roadmap —</option>
     </select>
-    <button onclick="saveRoadmap()" class="primary" style="font-size:12px;padding:4px 12px">Save</button>
+    <button id="save-btn" onclick="saveRoadmap()" class="primary" style="font-size:12px;padding:4px 12px">Save</button>
+    <span id="save-status" style="font-size:11px;display:none"></span>
     <button onclick="newRoadmap()" style="font-size:12px;padding:4px 12px">New</button>
     <div style="flex:1"></div>
     <button onclick="exportStateAsJson()" title="Export roadmap as JSON for sharing">⬇ Export JSON</button>

--- a/src/auth.js
+++ b/src/auth.js
@@ -86,6 +86,29 @@ export async function signOut() {
   updateAuthBar();
 }
 
+// ── UI helpers ───────────────────────────────────────────────────────────────
+
+let _statusTimer = null;
+
+function setSaveStatus(msg, type = 'loading') {
+  const el  = document.getElementById('save-status');
+  const btn = document.getElementById('save-btn');
+  if (!el) return;
+  clearTimeout(_statusTimer);
+  const colors = {
+    loading: 'var(--color-text-secondary)',
+    success: '#2E7D32',
+    error:   'var(--color-text-danger)',
+  };
+  el.textContent = msg;
+  el.style.color   = colors[type] || colors.loading;
+  el.style.display = 'inline';
+  if (btn) btn.disabled = type === 'loading';
+  if (type === 'success') {
+    _statusTimer = setTimeout(() => { el.style.display = 'none'; }, 3000);
+  }
+}
+
 // ── Roadmap CRUD ──────────────────────────────────────────────────────────────
 
 export async function loadRoadmapList() {
@@ -106,17 +129,23 @@ function renderRoadmapSelector(roadmaps) {
 
 export async function loadRoadmap(id) {
   if (!supabase || !id) return;
+  setSaveStatus('Loading…');
   const { data, error } = await supabase.from('roadmaps').select('*').eq('id', id).single();
-  if (error) { console.error('Failed to load roadmap:', error); return; }
-  state.workstreams       = data.workstreams;
-  state.features          = data.features;
-  state.nextId            = data.next_id;
-  state.currentRoadmapId  = data.id;
+  if (error) {
+    console.error('Failed to load roadmap:', error);
+    setSaveStatus(`Load failed: ${error.message}`, 'error');
+    return;
+  }
+  state.workstreams        = data.workstreams;
+  state.features           = data.features;
+  state.nextId             = data.next_id;
+  state.currentRoadmapId   = data.id;
   state.currentRoadmapName = data.name;
   const nameEl = document.getElementById('roadmap-name');
   if (nameEl) nameEl.value = data.name;
   populateFilters();
   render();
+  setSaveStatus('Loaded', 'success');
 }
 
 export async function saveRoadmap() {
@@ -124,6 +153,7 @@ export async function saveRoadmap() {
     persistState();
     return;
   }
+  setSaveStatus('Saving…');
   const name = document.getElementById('roadmap-name')?.value?.trim() || state.currentRoadmapName || 'Untitled';
   state.currentRoadmapName = name;
 
@@ -148,12 +178,13 @@ export async function saveRoadmap() {
 
   if (result.error) {
     console.error('Save failed:', result.error);
-    alert(`Save failed: ${result.error.message}`);
+    setSaveStatus(`Save failed: ${result.error.message}`, 'error');
     return;
   }
   state.currentRoadmapId = result.data.id;
   await loadRoadmapList();
   persistState();
+  setSaveStatus('Saved', 'success');
 }
 
 export async function newRoadmap() {


### PR DESCRIPTION
## Summary

- Adds a `#save-status` span next to the Save button in the roadmap bar
- `setSaveStatus(msg, type)` helper manages button state and status text: disables Save during in-flight requests, shows grey (loading), green (success), or red (error) text, auto-clears success after 3s
- `saveRoadmap` — Saving… → Saved / Save failed
- `loadRoadmap` — Loading… → Loaded / Load failed
- Prevents double-saves by disabling the Save button while a request is in flight

## Test plan
- [ ] Click Save — button disables, "Saving…" appears, "Saved" appears in green and fades after 3s
- [ ] Switch roadmaps from dropdown — "Loading…" appears, "Loaded" fades after 3s
- [ ] Double-click Save quickly — second click is blocked while first is in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)