### PR TITLE
Fix drag cursor flicker over bar elements (closes #18)

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -46,6 +46,7 @@ export function stopResize() {
 export function dragStart(e, fid) {
   dragSrc = fid;
   e.dataTransfer.effectAllowed = 'move';
+  document.body.classList.add('is-dragging');
 }
 
 export function dragOver(e) {
@@ -65,6 +66,7 @@ export function dragLeave(e) {
 
 export function dragEnd() {
   dragSrc = null;
+  document.body.classList.remove('is-dragging');
   document.querySelectorAll('.dragging-over').forEach(el => el.classList.remove('dragging-over'));
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -56,6 +56,7 @@ body {
 .bar .bar-resize-l,.bar .bar-resize-r { position:absolute;top:0;bottom:0;width:6px;cursor:ew-resize;z-index:2 }
 .bar .bar-resize-l { left:0;border-radius:3px 0 0 3px }
 .bar .bar-resize-r { right:0;border-radius:0 3px 3px 0 }
+body.is-dragging .bar, body.is-dragging .bar * { pointer-events:none }
 .legend { display:flex;flex-wrap:wrap;gap:10px;padding:8px 0 4px;align-items:center }
 .legend-item { display:flex;align-items:center;gap:4px;font-size:11px;color:var(--color-text-secondary) }
 .legend-dot { width:9px;height:9px;border-radius:50%;flex-shrink:0 }


### PR DESCRIPTION
Adds `body.is-dragging` class on `dragStart`/`dragEnd`. CSS rule `body.is-dragging .bar, body.is-dragging .bar * { pointer-events: none }` prevents bar and resize handle elements from intercepting pointer events mid-drag, eliminating the flickering `dragenter`/`dragleave` cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)