### PR TITLE
Fix magic link redirect URL to use app origin (fixes auth 404)

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -66,7 +66,8 @@ export async function submitSignIn() {
   btnEl.disabled = true;
   msgEl.style.display = 'none';
 
-  const { error } = await supabase.auth.signInWithOtp({ email });
+  const redirectTo = window.location.origin + (import.meta.env.BASE_URL || '/');
+  const { error } = await supabase.auth.signInWithOtp({ email, options: { emailRedirectTo: redirectTo } });
 
   if (error) {
     msgEl.textContent = `Error: ${error.message}`;


### PR DESCRIPTION
## Problem
The magic link was redirecting to the wrong URL (localhost or whatever is set in the Supabase dashboard) causing a 404 when clicked.

## Fix
Pass `emailRedirectTo` explicitly in `signInWithOtp` using `window.location.origin + import.meta.env.BASE_URL`. This means:
- On GitHub Pages: `https://bryanmillercbt.github.io/deployment-roadmap-builder/`
- On localhost dev: `http://localhost:5173/`

No longer depends on the Supabase dashboard Site URL setting.

## Test plan
- [ ] Click Sign in, enter email, receive magic link
- [ ] Click magic link — lands on the app (not a 404)
- [ ] Confirm session is established and auth bar shows your email

🤖 Generated with [Claude Code](https://claude.com/claude-code)