### PR TITLE
fix: Replace HTML5 drag API with mouse events (closes #18)

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -43,38 +43,47 @@ export function stopResize() {
   document.removeEventListener('mouseup', stopResize);
 }
 
-export function dragStart(e, fid) {
-  dragSrc = fid;
-  e.dataTransfer.effectAllowed = 'move';
+let rowDrag = null;
+
+export function rowDragMouseDown(e, fid) {
+  if (e.button !== 0) return;
+  e.preventDefault();
+  const f = state.features.find(x => x.id === fid);
+  if (!f) return;
+  rowDrag = { fid, ws: f.ws, targetFid: null };
   document.body.classList.add('is-dragging');
+  document.addEventListener('mousemove', onRowDragMove);
+  document.addEventListener('mouseup', onRowDragUp);
 }
 
-export function dragOver(e) {
-  e.preventDefault();
-}
-
-export function dragEnter(e, fid) {
-  e.preventDefault();
-  if (fid !== dragSrc) e.currentTarget.classList.add('dragging-over');
-}
-
-export function dragLeave(e) {
-  if (!e.currentTarget.contains(e.relatedTarget)) {
-    e.currentTarget.classList.remove('dragging-over');
+function onRowDragMove(e) {
+  if (!rowDrag) return;
+  document.querySelectorAll('.dragging-over').forEach(el => el.classList.remove('dragging-over'));
+  const el = document.elementFromPoint(e.clientX, e.clientY);
+  const row = el?.closest('[data-fid]');
+  const targetFid = row ? parseInt(row.dataset.fid) : null;
+  if (targetFid && targetFid !== rowDrag.fid) {
+    const tgt = state.features.find(x => x.id === targetFid);
+    if (tgt?.ws === rowDrag.ws) {
+      row.classList.add('dragging-over');
+      rowDrag.targetFid = targetFid;
+      return;
+    }
   }
+  rowDrag.targetFid = null;
 }
 
-export function dragEnd() {
-  dragSrc = null;
+function onRowDragUp() {
+  if (!rowDrag) return;
   document.body.classList.remove('is-dragging');
   document.querySelectorAll('.dragging-over').forEach(el => el.classList.remove('dragging-over'));
-}
-
-export function dropOn(e, fid) {
-  e.currentTarget.classList.remove('dragging-over');
-  if (!dragSrc || dragSrc === fid) return;
-  const src = state.features.find(x => x.id === dragSrc);
-  const tgt = state.features.find(x => x.id === fid);
+  document.removeEventListener('mousemove', onRowDragMove);
+  document.removeEventListener('mouseup', onRowDragUp);
+  const { fid, targetFid } = rowDrag;
+  rowDrag = null;
+  if (!targetFid || targetFid === fid) return;
+  const src = state.features.find(x => x.id === fid);
+  const tgt = state.features.find(x => x.id === targetFid);
   if (!src || !tgt || src.ws !== tgt.ws) return;
   const si = state.features.indexOf(src);
   const ti = state.features.indexOf(tgt);

--- a/src/main.js
+++ b/src/main.js
@@ -9,8 +9,7 @@ import {
   pickStart, pickEnd, openSignInModal, closeSignInModal,
 } from './modals.js';
 import {
-  startResize, doResize, stopResize,
-  dragStart, dragOver, dragEnter, dragLeave, dragEnd, dropOn, cellClick,
+  startResize, doResize, stopResize, rowDragMouseDown, cellClick,
 } from './interactions.js';
 import { exportToPptx } from './export/exportPptx.js';
 import { exportToGoogleSlides } from './export/exportGoogleSlides.js';
@@ -23,8 +22,7 @@ import {
 Object.assign(window, {
   render, openAddFeature, openEdit, openAddWorkstream, openEditWorkstream,
   saveFeature, deleteFeature, closeModal, saveWorkstream, deleteWorkstream,
-  pickStart, pickEnd, startResize, doResize, stopResize,
-  dragStart, dragOver, dragEnter, dragLeave, dragEnd, dropOn, cellClick,
+  pickStart, pickEnd, startResize, doResize, stopResize, rowDragMouseDown, cellClick,
   exportToPptx, exportToGoogleSlides, exportStateAsJson,
   showSignIn, signOut, submitSignIn, openSignInModal, closeSignInModal,
   saveRoadmap, newRoadmap,

--- a/src/render.js
+++ b/src/render.js
@@ -57,17 +57,10 @@ export function render() {
 
     wsFeatures.forEach(f => {
       const st = statusFor(f.status);
-      html += `<div class="feature-row" style="display:grid;grid-template-columns:${gridCols()}"
-        draggable="true"
-        ondragstart="dragStart(event,${f.id})"
-        ondragenter="dragEnter(event,${f.id})"
-        ondragover="dragOver(event)"
-        ondragleave="dragLeave(event)"
-        ondragend="dragEnd()"
-        ondrop="dropOn(event,${f.id})">`;
+      html += `<div class="feature-row" data-fid="${f.id}" style="display:grid;grid-template-columns:${gridCols()}">`;
 
       html += `<div class="feature-label">
-        <span class="drag-handle">⠿</span>
+        <span class="drag-handle" onmousedown="rowDragMouseDown(event,${f.id})">⠿</span>
         <span onclick="openEdit(${f.id})" style="cursor:pointer">${f.name}</span>
       </div>`;
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -56,6 +56,7 @@ body {
 .bar .bar-resize-l,.bar .bar-resize-r { position:absolute;top:0;bottom:0;width:6px;cursor:ew-resize;z-index:2 }
 .bar .bar-resize-l { left:0;border-radius:3px 0 0 3px }
 .bar .bar-resize-r { right:0;border-radius:0 3px 3px 0 }
+body.is-dragging { cursor:grabbing }
 body.is-dragging .bar, body.is-dragging .bar * { pointer-events:none }
 .legend { display:flex;flex-wrap:wrap;gap:10px;padding:8px 0 4px;align-items:center }
 .legend-item { display:flex;align-items:center;gap:4px;font-size:11px;color:var(--color-text-secondary) }


### PR DESCRIPTION
## Summary
- Removes HTML5 drag-and-drop API, which caused cursor flicker at element boundaries
- Implements mouse event-based row reordering (`mousedown`/`mousemove`/`mouseup` on document)
- Uses `elementFromPoint` + `closest("[data-fid]")` for clean drop target detection
- Adds `body.is-dragging` CSS class with `cursor:grabbing` and `pointer-events:none` on bars

## Test plan
- [ ] Drag a feature row up and down within its workstream — no cursor flicker
- [ ] Verify rows reorder correctly on drop
- [ ] Verify bars cannot be accidentally dragged (pointer-events:none while dragging)
- [ ] Verify cellClick and resize still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)