### PR TITLE
feat: Replace New Roadmap confirm() dialog with a modal (closes #4)

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,18 @@
     </div>
   </div>
 
+  <!-- New Roadmap confirmation modal -->
+  <div class="modal-bg" id="new-roadmap-modal-bg">
+    <div class="modal" style="width:320px">
+      <h3>Start new roadmap?</h3>
+      <p style="font-size:12px;color:var(--color-text-secondary);margin:0 0 16px">Any unsaved changes will be lost.</p>
+      <div class="modal-actions">
+        <button onclick="closeNewRoadmapModal()">Cancel</button>
+        <button class="danger" onclick="confirmNewRoadmap()">Start new</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Sign-in modal -->
   <div class="modal-bg" id="signin-modal-bg">
     <div class="modal">

--- a/src/auth.js
+++ b/src/auth.js
@@ -2,7 +2,7 @@ import { createClient } from '@supabase/supabase-js';
 import { state, persistState } from './state.js';
 import { render } from './render.js';
 import { populateFilters } from './filters.js';
-import { openSignInModal, closeSignInModal } from './modals.js';
+import { openSignInModal, closeSignInModal, closeNewRoadmapModal } from './modals.js';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -189,7 +189,11 @@ export async function saveRoadmap() {
 }
 
 export async function newRoadmap() {
-  if (!confirm('Start a new roadmap? Unsaved changes will be lost.')) return;
+  window.openNewRoadmapModal();
+}
+
+export async function confirmNewRoadmap() {
+  closeNewRoadmapModal();
   state.currentRoadmapId   = null;
   state.currentRoadmapName = 'New Roadmap';
   state.workstreams = [

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import {
   initModals, openAddFeature, openEdit, openAddWorkstream, openEditWorkstream,
   saveFeature, deleteFeature, closeModal, saveWorkstream, deleteWorkstream,
   pickStart, pickEnd, openSignInModal, closeSignInModal,
+  openNewRoadmapModal, closeNewRoadmapModal,
 } from './modals.js';
 import {
   startResize, doResize, stopResize, rowDragMouseDown, cellClick,
@@ -15,7 +16,7 @@ import { exportToPptx } from './export/exportPptx.js';
 import { exportToGoogleSlides } from './export/exportGoogleSlides.js';
 import {
   initAuth, isConfigured, showSignIn, signOut, submitSignIn,
-  loadRoadmap, saveRoadmap, newRoadmap, subscribeRealtime,
+  loadRoadmap, saveRoadmap, newRoadmap, confirmNewRoadmap, subscribeRealtime,
 } from './auth.js';
 
 // Expose all functions called from inline onclick handlers in render()
@@ -25,7 +26,8 @@ Object.assign(window, {
   pickStart, pickEnd, startResize, doResize, stopResize, rowDragMouseDown, cellClick,
   exportToPptx, exportToGoogleSlides, exportStateAsJson,
   showSignIn, signOut, submitSignIn, openSignInModal, closeSignInModal,
-  saveRoadmap, newRoadmap,
+  openNewRoadmapModal, closeNewRoadmapModal,
+  saveRoadmap, newRoadmap, confirmNewRoadmap,
   handleRoadmapSelect: async (e) => {
     const id = e.target.value;
     if (id) {

--- a/src/modals.js
+++ b/src/modals.js
@@ -142,6 +142,14 @@ export function deleteWorkstream() {
   persistState();
 }
 
+export function openNewRoadmapModal() {
+  document.getElementById('new-roadmap-modal-bg').classList.add('open');
+}
+
+export function closeNewRoadmapModal() {
+  document.getElementById('new-roadmap-modal-bg').classList.remove('open');
+}
+
 export function openSignInModal() {
   document.getElementById('signin-email').value = '';
   const msg = document.getElementById('signin-message');
@@ -168,5 +176,8 @@ export function initModals() {
   });
   document.getElementById('signin-email').addEventListener('keydown', function(e) {
     if (e.key === 'Enter') window.submitSignIn();
+  });
+  document.getElementById('new-roadmap-modal-bg').addEventListener('click', function(e) {
+    if (e.target === this) closeNewRoadmapModal();
   });
 }


### PR DESCRIPTION
## Summary
- Removes browser `confirm()` dialog from the New Roadmap flow
- Adds a dedicated confirmation modal with Cancel / Start new buttons
- Backdrop click closes the modal
- `newRoadmap()` now opens the modal; `confirmNewRoadmap()` executes the reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)