### PR TITLE
feat: Drag bars horizontally on the Gantt to reposition features (closes #17)

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -3,7 +3,7 @@ import { state, persistState } from './state.js';
 import { render } from './render.js';
 
 let resizing = null;
-let dragSrc = null;
+let barDrag  = null;
 
 export function cellClick(fid, mi) {
   const f = state.features.find(x => x.id === fid);
@@ -41,6 +41,50 @@ export function stopResize() {
   resizing = null;
   document.removeEventListener('mousemove', doResize);
   document.removeEventListener('mouseup', stopResize);
+}
+
+// ── Bar drag (move entire bar horizontally) ───────────────────────────────────
+
+export function startBarDrag(e, fid) {
+  if (e.button !== 0) return;
+  e.stopPropagation();
+  e.preventDefault();
+  const f = state.features.find(x => x.id === fid);
+  if (!f) return;
+  barDrag = { fid, startX: e.clientX, orig: { start: f.start, end: f.end }, moved: false };
+  document.addEventListener('mousemove', doBarDrag);
+  document.addEventListener('mouseup', stopBarDrag);
+}
+
+function doBarDrag(e) {
+  if (!barDrag) return;
+  const dx = e.clientX - barDrag.startX;
+  if (!barDrag.moved && Math.abs(dx) < 5) return;
+  barDrag.moved = true;
+  document.body.classList.add('is-dragging');
+  const cfg = getConfig();
+  const dMonths = Math.round(dx / cfg.colWidth);
+  const f = state.features.find(x => x.id === barDrag.fid);
+  if (!f) return;
+  const duration = barDrag.orig.end - barDrag.orig.start;
+  const newStart = Math.max(0, Math.min(cfg.months.length - 1 - duration, barDrag.orig.start + dMonths));
+  f.start = newStart;
+  f.end   = newStart + duration;
+  render();
+}
+
+function stopBarDrag() {
+  if (!barDrag) return;
+  document.removeEventListener('mousemove', doBarDrag);
+  document.removeEventListener('mouseup', stopBarDrag);
+  document.body.classList.remove('is-dragging');
+  const { fid, moved } = barDrag;
+  barDrag = null;
+  if (moved) {
+    persistState();
+  } else {
+    window.openEdit(fid);
+  }
 }
 
 let rowDrag = null;

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ import {
   openNewRoadmapModal, closeNewRoadmapModal,
 } from './modals.js';
 import {
-  startResize, doResize, stopResize, rowDragMouseDown, cellClick,
+  startResize, doResize, stopResize, rowDragMouseDown, cellClick, startBarDrag,
 } from './interactions.js';
 import { exportToPptx } from './export/exportPptx.js';
 import { exportToGoogleSlides } from './export/exportGoogleSlides.js';
@@ -23,7 +23,7 @@ import {
 Object.assign(window, {
   render, openAddFeature, openEdit, openAddWorkstream, openEditWorkstream,
   saveFeature, deleteFeature, closeModal, saveWorkstream, deleteWorkstream,
-  pickStart, pickEnd, startResize, doResize, stopResize, rowDragMouseDown, cellClick,
+  pickStart, pickEnd, startResize, doResize, stopResize, rowDragMouseDown, cellClick, startBarDrag,
   exportToPptx, exportToGoogleSlides, exportStateAsJson,
   showSignIn, signOut, submitSignIn, openSignInModal, closeSignInModal,
   openNewRoadmapModal, closeNewRoadmapModal,

--- a/src/render.js
+++ b/src/render.js
@@ -71,7 +71,7 @@ export function render() {
         if (isStart) {
           html += `<div class="bar"
             style="left:4px;width:${totalW}px;background:${st.fill};border:1px solid ${st.color};color:${st.color}"
-            onclick="openEdit(${f.id});event.stopPropagation()">
+            onmousedown="startBarDrag(event,${f.id})">
             <div class="bar-resize-l" onmousedown="startResize(event,${f.id},'l')"></div>
             <span style="overflow:hidden;text-overflow:ellipsis">${f.name}</span>
             <div class="bar-resize-r" onmousedown="startResize(event,${f.id},'r')"></div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -51,7 +51,7 @@ body {
 .feature-label .drag-handle { cursor:grab;color:var(--color-text-tertiary);font-size:13px }
 .cell { border-right:0.5px solid var(--color-border-tertiary);height:100%;min-height:28px;position:relative;cursor:pointer }
 .cell.alt { background:rgba(0,0,0,.015) }
-.bar { position:absolute;top:4px;bottom:4px;border-radius:3px;display:flex;align-items:center;padding:0 5px;font-size:10px;font-weight:500;white-space:nowrap;overflow:hidden;cursor:pointer;transition:opacity .1s }
+.bar { position:absolute;top:4px;bottom:4px;border-radius:3px;display:flex;align-items:center;padding:0 5px;font-size:10px;font-weight:500;white-space:nowrap;overflow:hidden;cursor:grab;transition:opacity .1s }
 .bar:hover { opacity:.85;filter:brightness(1.05) }
 .bar .bar-resize-l,.bar .bar-resize-r { position:absolute;top:0;bottom:0;width:6px;cursor:ew-resize;z-index:2 }
 .bar .bar-resize-l { left:0;border-radius:3px 0 0 3px }


### PR DESCRIPTION
## Summary
- Mousedown on a bar body now starts a horizontal drag to shift the feature in time
- Drag vs click is disambiguated by a 5px movement threshold — small movements still open the edit modal
- Duration is preserved: both `start` and `end` shift together
- Clamped to valid month range so bars cannot be dragged off the grid
- Bar cursor changed to `grab` (becomes `grabbing` while dragging via existing `body.is-dragging` CSS)
- Resize handles are unaffected — they call `stopPropagation()` so bar drag never fires

## Test plan
- [ ] Drag a bar left and right — it moves smoothly, cursor stays `grabbing`
- [ ] Drop updates the feature position and persists after reload
- [ ] Short click (no drag) still opens the edit modal
- [ ] Resize handles (left/right edges) still work independently
- [ ] Bar cannot be dragged past the first or last month

🤖 Generated with [Claude Code](https://claude.com/claude-code)