### PR TITLE
feat: Load release schedule from Supabase at runtime (closes #8)

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -3,6 +3,7 @@ import { state, persistState } from './state.js';
 import { render } from './render.js';
 import { populateFilters } from './filters.js';
 import { openSignInModal, closeSignInModal, closeNewRoadmapModal } from './modals.js';
+import { setReleases } from './config.js';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -10,6 +11,7 @@ const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 export let supabase = null;
 let currentUser = null;
 let realtimeChannel = null;
+let releasesChannel = null;
 
 export function isConfigured() {
   return !!(SUPABASE_URL && SUPABASE_KEY);
@@ -35,6 +37,29 @@ export async function initAuth() {
   });
 
   if (currentUser) await loadRoadmapList();
+
+  await loadReleases();
+  subscribeReleasesRealtime();
+}
+
+async function loadReleases() {
+  if (!supabase) return;
+  const { data, error } = await supabase
+    .from('releases')
+    .select('label, start_month, end_month, bg')
+    .order('sort_order');
+  if (error || !data?.length) return;
+  setReleases(data.map(r => ({ label: r.label, start: r.start_month, end: r.end_month, bg: r.bg })));
+  render();
+}
+
+function subscribeReleasesRealtime() {
+  if (!supabase) return;
+  if (releasesChannel) supabase.removeChannel(releasesChannel);
+  releasesChannel = supabase
+    .channel('releases')
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'releases' }, loadReleases)
+    .subscribe();
 }
 
 function updateAuthBar() {

--- a/src/config.js
+++ b/src/config.js
@@ -37,3 +37,8 @@ export async function initConfig() {
 export function getConfig() {
   return _config || DEFAULT_CONFIG;
 }
+
+export function setReleases(arr) {
+  const cfg = _config || DEFAULT_CONFIG;
+  cfg.releases = arr;
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -45,3 +45,27 @@ create policy "Users can delete own roadmaps"
 -- Enable Realtime for live sync
 -- Run this separately in the Supabase dashboard:
 --   Table Editor → roadmaps → Realtime → Enable
+
+-- ── Release schedule (admin-managed, publicly readable) ──────────────────────
+
+create table if not exists releases (
+  id          serial primary key,
+  label       text     not null,
+  start_month smallint not null,
+  end_month   smallint not null,
+  bg          text     not null default '#e8f4fd',
+  sort_order  smallint not null default 0
+);
+
+alter table releases enable row level security;
+
+create policy "releases_public_read" on releases
+  for select using (true);
+
+-- Seed with default schedule (edit directly in Supabase to update)
+insert into releases (label, start_month, end_month, bg, sort_order) values
+  ('Winter 26', 0,  2,  '#DDE3F0', 0),
+  ('Spring 26', 3,  5,  '#C8E6C9', 1),
+  ('Summer 26', 6,  8,  '#FFE0B2', 2),
+  ('Winter 27', 9,  11, '#E1BEE7', 3)
+on conflict do nothing;


### PR DESCRIPTION
## Summary
- Creates `releases` table in Supabase with public read-only RLS
- Seeded with the current Winter/Spring/Summer/Winter 26-27 schedule
- App fetches releases at startup and overrides the `config.json` fallback
- Subscribes to Realtime changes — if you edit a row in the Supabase table editor, all open browser sessions redraw the Gantt bands within seconds
- Offline / no-Supabase mode falls back gracefully to `config.json`

## How to update releases
Go to Supabase Table Editor → `releases` table → edit any row. Fields:
- `label` — display name shown in the band header
- `start_month` / `end_month` — 0-indexed (FEB=0 … JAN=11)
- `bg` — hex background color for the band
- `sort_order` — controls left-to-right order

🤖 Generated with [Claude Code](https://claude.com/claude-code)