### PR TITLE
fix: Switch releases table to date columns (start_date / end_date)

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,4 +1,5 @@
 {
+  "ganttStartDate": "2026-02-01",
   "months": ["FEB","MAR","APR","MAY","JUN","JUL","AUG","SEP","OCT","NOV","DEC","JAN"],
   "currentMonth": 2,
   "colWidth": 60,

--- a/src/auth.js
+++ b/src/auth.js
@@ -3,7 +3,7 @@ import { state, persistState } from './state.js';
 import { render } from './render.js';
 import { populateFilters } from './filters.js';
 import { openSignInModal, closeSignInModal, closeNewRoadmapModal } from './modals.js';
-import { setReleases } from './config.js';
+import { getConfig, setReleases } from './config.js';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -42,14 +42,26 @@ export async function initAuth() {
   subscribeReleasesRealtime();
 }
 
+function dateToMonthIndex(dateStr) {
+  const cfg = getConfig();
+  const origin = new Date(cfg.ganttStartDate);
+  const d      = new Date(dateStr);
+  return (d.getFullYear() - origin.getFullYear()) * 12 + (d.getMonth() - origin.getMonth());
+}
+
 async function loadReleases() {
   if (!supabase) return;
   const { data, error } = await supabase
     .from('releases')
-    .select('label, start_month, end_month, bg')
+    .select('label, start_date, end_date, bg')
     .order('sort_order');
   if (error || !data?.length) return;
-  setReleases(data.map(r => ({ label: r.label, start: r.start_month, end: r.end_month, bg: r.bg })));
+  setReleases(data.map(r => ({
+    label: r.label,
+    start: dateToMonthIndex(r.start_date),
+    end:   dateToMonthIndex(r.end_date),
+    bg:    r.bg,
+  })));
   render();
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 const DEFAULT_CONFIG = {
+  ganttStartDate: "2026-02-01",
   months: ["FEB","MAR","APR","MAY","JUN","JUL","AUG","SEP","OCT","NOV","DEC","JAN"],
   currentMonth: 2,
   colWidth: 60,

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -49,11 +49,11 @@ create policy "Users can delete own roadmaps"
 -- ── Release schedule (admin-managed, publicly readable) ──────────────────────
 
 create table if not exists releases (
-  id          serial primary key,
-  label       text     not null,
-  start_month smallint not null,
-  end_month   smallint not null,
-  bg          text     not null default '#e8f4fd',
+  id          serial  primary key,
+  label       text    not null,
+  start_date  date    not null,
+  end_date    date    not null,
+  bg          text    not null default '#e8f4fd',
   sort_order  smallint not null default 0
 );
 
@@ -63,9 +63,11 @@ create policy "releases_public_read" on releases
   for select using (true);
 
 -- Seed with default schedule (edit directly in Supabase to update)
-insert into releases (label, start_month, end_month, bg, sort_order) values
-  ('Winter 26', 0,  2,  '#DDE3F0', 0),
-  ('Spring 26', 3,  5,  '#C8E6C9', 1),
-  ('Summer 26', 6,  8,  '#FFE0B2', 2),
-  ('Winter 27', 9,  11, '#E1BEE7', 3)
+-- start_date / end_date are the first day of the start and end month
+-- The Gantt maps these to column indices using ganttStartDate in config.json
+insert into releases (label, start_date, end_date, bg, sort_order) values
+  ('Winter 26', '2026-02-01', '2026-04-01', '#DDE3F0', 0),
+  ('Spring 26', '2026-05-01', '2026-07-01', '#C8E6C9', 1),
+  ('Summer 26', '2026-08-01', '2026-10-01', '#FFE0B2', 2),
+  ('Winter 27', '2026-11-01', '2027-01-01', '#E1BEE7', 3)
 on conflict do nothing;


### PR DESCRIPTION
## Summary
- Migrated `start_month`/`end_month` (smallint) to `start_date`/`end_date` (date) on the `releases` table
- Existing rows converted: index 0 = 2026-02-01
- Added `ganttStartDate` to `config.json` and the JS default config — this is the reference date for month index 0
- `loadReleases()` now converts date strings to column indices via `dateToMonthIndex()`

## Editing releases going forward
In Supabase Table Editor → `releases`:
- Set `start_date` and `end_date` to the first of the start/end month (e.g. `2026-05-01`)
- The app computes the column index automatically using `ganttStartDate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)