### PR TITLE
feat: Replace workstream color select with a color picker (closes #6)

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,15 +91,7 @@
       </div>
       <div class="form-row">
         <label>Color</label>
-        <select id="ws-color-input">
-          <option value="#4A6FA5">Blue</option>
-          <option value="#2E8B57">Green</option>
-          <option value="#B8621A">Orange</option>
-          <option value="#5B4B8A">Purple</option>
-          <option value="#C0392B">Red</option>
-          <option value="#16A085">Teal</option>
-          <option value="#7D6608">Olive</option>
-        </select>
+        <input type="color" id="ws-color-input" value="#4A6FA5" style="width:100%;height:36px;padding:2px 4px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);cursor:pointer" />
       </div>
       <div class="modal-actions">
         <button id="ws-delete-btn" class="danger" style="margin-right:auto;display:none" onclick="deleteWorkstream()">Delete workstream</button>


### PR DESCRIPTION
Replaces the 7-option color dropdown with a native `<input type="color">` so any color can be chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)