### PR TITLE
feat: Add created_at column to roadmaps table (closes #7)

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -7,6 +7,7 @@ create table if not exists roadmaps (
   features    jsonb not null default '[]',
   next_id     int  not null default 1,
   created_by  uuid references auth.users on delete set null,
+  created_at  timestamptz not null default now(),
   updated_at  timestamptz default now()
 );
 


### PR DESCRIPTION
Adds `created_at timestamptz not null default now()` to the roadmaps table via migration. Schema doc updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)