### PR TITLE
feat: Add setup wizard for first-time roadmap configuration (closes #11)

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,22 @@
     </div>
   </div>
 
+  <!-- Setup wizard -->
+  <div class="modal-bg" id="wizard-modal-bg">
+    <div class="modal" style="width:420px">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px">
+        <h3 id="wizard-title" style="margin:0">Welcome</h3>
+        <span id="wizard-step-indicator" style="font-size:11px;color:var(--color-text-tertiary)">Step 1 of 3</span>
+      </div>
+      <div id="wizard-content"></div>
+      <div class="modal-actions" style="margin-top:18px">
+        <button onclick="wizardSkip()" style="margin-right:auto;color:var(--color-text-tertiary);border-color:transparent;background:transparent">Skip</button>
+        <button id="wizard-back-btn" style="display:none" onclick="wizardBack()">← Back</button>
+        <button class="save" id="wizard-next-btn" onclick="wizardNext()">Next →</button>
+      </div>
+    </div>
+  </div>
+
   <!-- New Roadmap confirmation modal -->
   <div class="modal-bg" id="new-roadmap-modal-bg">
     <div class="modal" style="width:320px">

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,10 @@ import {
 import { exportToPptx } from './export/exportPptx.js';
 import { exportToGoogleSlides } from './export/exportGoogleSlides.js';
 import {
+  initWizard, shouldShowWizard, openWizard,
+  wizardNext, wizardBack, wizardSkip, wizardAddWorkstream, wizardRemoveWorkstream,
+} from './wizard.js';
+import {
   initAuth, isConfigured, showSignIn, signOut, submitSignIn,
   loadRoadmap, saveRoadmap, newRoadmap, confirmNewRoadmap, subscribeRealtime,
 } from './auth.js';
@@ -28,6 +32,7 @@ Object.assign(window, {
   showSignIn, signOut, submitSignIn, openSignInModal, closeSignInModal,
   openNewRoadmapModal, closeNewRoadmapModal,
   saveRoadmap, newRoadmap, confirmNewRoadmap,
+  openWizard, wizardNext, wizardBack, wizardSkip, wizardAddWorkstream, wizardRemoveWorkstream,
   handleRoadmapSelect: async (e) => {
     const id = e.target.value;
     if (id) {
@@ -51,9 +56,11 @@ async function init() {
   initState();
   await initAuth();
   initModals();
+  initWizard();
   populateFilters();
   renderLegend();
   render();
+  if (shouldShowWizard()) openWizard();
 
   // Wire up roadmap name input
   const nameEl = document.getElementById('roadmap-name');

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -76,6 +76,18 @@ body.is-dragging .bar, body.is-dragging .bar * { pointer-events:none }
 .modal-actions button.save { background:#232F3E;color:#fff;border-color:#232F3E }
 .modal-actions button.danger { background:var(--color-background-danger);color:var(--color-text-danger);border-color:var(--color-border-danger) }
 
+/* Setup wizard */
+.wizard-desc { font-size:12px;color:var(--color-text-secondary);margin-bottom:14px }
+.wizard-ws-row { display:flex;align-items:center;gap:8px;margin-bottom:8px }
+.wizard-ws-row .wizard-ws-color { width:36px;height:32px;padding:2px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);cursor:pointer;flex-shrink:0 }
+.wizard-ws-row .wizard-ws-name { flex:1;font-size:13px;padding:6px 8px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary) }
+.wizard-ws-remove { font-size:11px;padding:2px 8px;border:0.5px solid var(--color-border-danger);border-radius:var(--border-radius-md);background:var(--color-background-danger);color:var(--color-text-danger);cursor:pointer }
+.wizard-add-ws { font-size:11px;padding:4px 10px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-secondary);cursor:pointer;margin-top:4px }
+.wizard-summary-row { font-size:12px;margin-bottom:8px }
+.wizard-summary-label { font-size:11px;font-weight:500;color:var(--color-text-secondary) }
+.wizard-summary-ws { display:flex;align-items:center;gap:8px;font-size:12px;margin-bottom:6px }
+.wizard-ws-swatch { width:10px;height:10px;border-radius:50%;flex-shrink:0 }
+
 /* Roadmap selector */
 .roadmap-bar { display:flex;align-items:center;gap:8px;padding:8px 0;margin-bottom:4px;font-size:12px;color:var(--color-text-secondary) }
 .roadmap-bar select { font-size:12px;padding:4px 8px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary);min-width:200px }

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -1,0 +1,159 @@
+import { state, persistState } from './state.js';
+import { populateFilters } from './filters.js';
+import { render } from './render.js';
+
+const WIZARD_KEY = 'roadmap_wizard_done';
+
+let wizardWs   = [];
+let currentStep = 1;
+const TOTAL_STEPS = 3;
+
+export function shouldShowWizard() {
+  return !localStorage.getItem(WIZARD_KEY) && state.features.length === 0;
+}
+
+export function openWizard() {
+  wizardWs    = state.workstreams.map(ws => ({ ...ws }));
+  currentStep = 1;
+  renderWizardStep();
+  document.getElementById('wizard-modal-bg').classList.add('open');
+}
+
+function closeWizard(markDone = true) {
+  document.getElementById('wizard-modal-bg').classList.remove('open');
+  if (markDone) localStorage.setItem(WIZARD_KEY, '1');
+}
+
+export function wizardSkip() {
+  closeWizard(true);
+}
+
+export function wizardNext() {
+  if (currentStep === 1) {
+    const name = document.getElementById('wizard-roadmap-name').value.trim();
+    if (!name) { document.getElementById('wizard-roadmap-name').focus(); return; }
+    state.currentRoadmapName = name;
+    const nameEl = document.getElementById('roadmap-name');
+    if (nameEl) nameEl.value = name;
+  }
+  if (currentStep === 2) collectWizardWorkstreams();
+
+  if (currentStep < TOTAL_STEPS) {
+    currentStep++;
+    renderWizardStep();
+  } else {
+    finishWizard();
+  }
+}
+
+export function wizardBack() {
+  if (currentStep === 2) collectWizardWorkstreams();
+  if (currentStep > 1) {
+    currentStep--;
+    renderWizardStep();
+  }
+}
+
+function collectWizardWorkstreams() {
+  wizardWs = Array.from(document.querySelectorAll('.wizard-ws-row')).map(row => ({
+    id:    row.dataset.wsid,
+    name:  row.querySelector('.wizard-ws-name').value.trim(),
+    color: row.querySelector('.wizard-ws-color').value,
+  })).filter(ws => ws.name);
+}
+
+export function wizardAddWorkstream() {
+  collectWizardWorkstreams();
+  wizardWs.push({ id: `ws-${Date.now()}`, name: '', color: '#4A6FA5' });
+  renderWizardStep();
+  const rows = document.querySelectorAll('.wizard-ws-row');
+  rows[rows.length - 1]?.querySelector('.wizard-ws-name')?.focus();
+}
+
+export function wizardRemoveWorkstream(idx) {
+  collectWizardWorkstreams();
+  wizardWs.splice(idx, 1);
+  renderWizardStep();
+}
+
+function finishWizard() {
+  collectWizardWorkstreams();
+  if (wizardWs.length === 0) {
+    wizardWs = [{ id: 'general', name: 'General', color: '#4A6FA5' }];
+  }
+  state.workstreams = wizardWs;
+  state.features    = [];
+  state.nextId      = 1;
+  populateFilters();
+  render();
+  persistState();
+  closeWizard(true);
+}
+
+function renderWizardStep() {
+  const content = document.getElementById('wizard-content');
+  const title   = document.getElementById('wizard-title');
+  const stepEl  = document.getElementById('wizard-step-indicator');
+  const backBtn = document.getElementById('wizard-back-btn');
+  const nextBtn = document.getElementById('wizard-next-btn');
+
+  stepEl.textContent      = `Step ${currentStep} of ${TOTAL_STEPS}`;
+  backBtn.style.display   = currentStep > 1 ? 'inline-block' : 'none';
+  nextBtn.textContent     = currentStep === TOTAL_STEPS ? 'Finish' : 'Next →';
+
+  if (currentStep === 1) {
+    title.textContent = 'Name your roadmap';
+    content.innerHTML = `
+      <p class="wizard-desc">Give this roadmap a name — typically the customer or project it covers.</p>
+      <div class="form-row">
+        <label>Roadmap name</label>
+        <input type="text" id="wizard-roadmap-name"
+          placeholder="e.g. Acme Corp Deployment"
+          value="${state.currentRoadmapName && state.currentRoadmapName !== 'My Roadmap' ? state.currentRoadmapName : ''}" />
+      </div>
+    `;
+    setTimeout(() => document.getElementById('wizard-roadmap-name')?.focus(), 50);
+
+  } else if (currentStep === 2) {
+    title.textContent = 'Define your workstreams';
+    content.innerHTML = `
+      <p class="wizard-desc">Workstreams are the swim lanes in your Gantt. Edit the defaults or add your own.</p>
+      <div id="wizard-ws-list">
+        ${wizardWs.map((ws, i) => `
+          <div class="wizard-ws-row" data-wsid="${ws.id}">
+            <input type="color" class="wizard-ws-color" value="${ws.color}" />
+            <input type="text"  class="wizard-ws-name"  value="${ws.name}" placeholder="Workstream name" />
+            ${wizardWs.length > 1
+              ? `<button class="wizard-ws-remove" onclick="wizardRemoveWorkstream(${i})">✕</button>`
+              : '<span style="width:28px"></span>'}
+          </div>
+        `).join('')}
+      </div>
+      <button class="wizard-add-ws" onclick="wizardAddWorkstream()">+ Add workstream</button>
+    `;
+
+  } else if (currentStep === 3) {
+    const validWs = wizardWs.filter(ws => ws.name);
+    title.textContent = "You're all set!";
+    content.innerHTML = `
+      <p class="wizard-desc">Here's what you've configured. Click <strong>Finish</strong> to open your roadmap.</p>
+      <div class="wizard-summary-row"><span class="wizard-summary-label">Roadmap</span>${state.currentRoadmapName}</div>
+      <div class="wizard-summary-label" style="margin:12px 0 6px">Workstreams</div>
+      ${validWs.map(ws => `
+        <div class="wizard-summary-ws">
+          <div class="wizard-ws-swatch" style="background:${ws.color}"></div>
+          <span>${ws.name}</span>
+        </div>
+      `).join('')}
+      <p class="wizard-desc" style="margin-top:16px">
+        Add features by clicking <strong>+ Add feature</strong> in the toolbar, or by clicking any cell in the chart.
+      </p>
+    `;
+  }
+}
+
+export function initWizard() {
+  document.getElementById('wizard-modal-bg').addEventListener('keydown', e => {
+    if (e.key === 'Enter' && currentStep !== 2) wizardNext();
+  });
+}


### PR DESCRIPTION
## Summary
- 3-step modal wizard auto-triggers on first load when state is empty
- Step 1: Name the roadmap
- Step 2: Define workstreams — editable list with color pickers, add/remove rows
- Step 3: Summary of configuration + finish
- Skip button dismisses permanently; completion stored in `localStorage`
- Wizard never shows again after completion or skip
- Finish commits workstreams to state and renders the Gantt

## Test plan
- [ ] Clear localStorage and reload — wizard appears automatically
- [ ] Step 1: entering a name and clicking Next advances the step
- [ ] Step 2: can rename, recolor, add, and remove workstreams
- [ ] Step 3: shows correct summary
- [ ] Finish: Gantt renders with configured workstreams, wizard does not re-appear on reload
- [ ] Skip: wizard closes, does not re-appear on reload
- [ ] Back navigation works between steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)