### PR TITLE
feat: Expand setup wizard to 4 steps with features and dynamic start date (closes #11)

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
 
   <!-- Setup wizard -->
   <div class="modal-bg" id="wizard-modal-bg">
-    <div class="modal" style="width:420px">
+    <div class="modal" style="width:480px">
       <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px">
         <h3 id="wizard-title" style="margin:0">Welcome</h3>
         <span id="wizard-step-indicator" style="font-size:11px;color:var(--color-text-tertiary)">Step 1 of 3</span>

--- a/src/config.js
+++ b/src/config.js
@@ -43,3 +43,16 @@ export function setReleases(arr) {
   const cfg = _config || DEFAULT_CONFIG;
   cfg.releases = arr;
 }
+
+const MONTH_ABBR = ['JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC'];
+
+export function refreshConfigFromStartDate(dateStr) {
+  if (!dateStr) return;
+  const start = new Date(dateStr + 'T00:00:00');
+  const cfg   = _config || DEFAULT_CONFIG;
+  cfg.ganttStartDate = dateStr;
+  cfg.months = Array.from({ length: 12 }, (_, i) => MONTH_ABBR[(start.getMonth() + i) % 12]);
+  const now  = new Date();
+  const diff = (now.getFullYear() - start.getFullYear()) * 12 + (now.getMonth() - start.getMonth());
+  cfg.currentMonth = Math.max(0, Math.min(11, diff));
+}

--- a/src/main.js
+++ b/src/main.js
@@ -16,8 +16,11 @@ import { exportToPptx } from './export/exportPptx.js';
 import { exportToGoogleSlides } from './export/exportGoogleSlides.js';
 import {
   initWizard, shouldShowWizard, openWizard,
-  wizardNext, wizardBack, wizardSkip, wizardAddWorkstream, wizardRemoveWorkstream,
+  wizardNext, wizardBack, wizardSkip,
+  wizardAddWorkstream, wizardRemoveWorkstream,
+  wizardAddFeature, wizardRemoveFeature,
 } from './wizard.js';
+import { refreshConfigFromStartDate } from './config.js';
 import {
   initAuth, isConfigured, showSignIn, signOut, submitSignIn,
   loadRoadmap, saveRoadmap, newRoadmap, confirmNewRoadmap, subscribeRealtime,
@@ -32,7 +35,9 @@ Object.assign(window, {
   showSignIn, signOut, submitSignIn, openSignInModal, closeSignInModal,
   openNewRoadmapModal, closeNewRoadmapModal,
   saveRoadmap, newRoadmap, confirmNewRoadmap,
-  openWizard, wizardNext, wizardBack, wizardSkip, wizardAddWorkstream, wizardRemoveWorkstream,
+  openWizard, wizardNext, wizardBack, wizardSkip,
+  wizardAddWorkstream, wizardRemoveWorkstream,
+  wizardAddFeature, wizardRemoveFeature,
   handleRoadmapSelect: async (e) => {
     const id = e.target.value;
     if (id) {
@@ -54,6 +59,7 @@ Object.assign(window, {
 async function init() {
   await initConfig();
   initState();
+  if (state.ganttStartDate) refreshConfigFromStartDate(state.ganttStartDate);
   await initAuth();
   initModals();
   initWizard();

--- a/src/state.js
+++ b/src/state.js
@@ -1,6 +1,7 @@
 const LOCAL_KEY = 'roadmap_local_data';
 
 export const state = {
+  ganttStartDate: '2026-02-01',
   workstreams: [
     { id: "staffing",   name: "Staffing",   color: "#4A6FA5" },
     { id: "delivery",   name: "Delivery",   color: "#2E8B57" },
@@ -25,9 +26,10 @@ export function initState() {
     const raw = localStorage.getItem(LOCAL_KEY);
     if (raw) {
       const saved = JSON.parse(raw);
-      if (saved.workstreams)       state.workstreams       = saved.workstreams;
-      if (saved.features)          state.features          = saved.features;
-      if (saved.nextId)            state.nextId            = saved.nextId;
+      if (saved.ganttStartDate)     state.ganttStartDate     = saved.ganttStartDate;
+      if (saved.workstreams)        state.workstreams        = saved.workstreams;
+      if (saved.features)           state.features           = saved.features;
+      if (saved.nextId)             state.nextId             = saved.nextId;
       if (saved.currentRoadmapName) state.currentRoadmapName = saved.currentRoadmapName;
     }
   } catch (_) {}
@@ -35,6 +37,7 @@ export function initState() {
 
 export function persistState() {
   localStorage.setItem(LOCAL_KEY, JSON.stringify({
+    ganttStartDate:    state.ganttStartDate,
     workstreams:       state.workstreams,
     features:          state.features,
     nextId:            state.nextId,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -78,14 +78,27 @@ body.is-dragging .bar, body.is-dragging .bar * { pointer-events:none }
 
 /* Setup wizard */
 .wizard-desc { font-size:12px;color:var(--color-text-secondary);margin-bottom:14px }
+.wizard-empty { font-size:11px;color:var(--color-text-tertiary);margin-bottom:10px }
 .wizard-ws-row { display:flex;align-items:center;gap:8px;margin-bottom:8px }
 .wizard-ws-row .wizard-ws-color { width:36px;height:32px;padding:2px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);cursor:pointer;flex-shrink:0 }
 .wizard-ws-row .wizard-ws-name { flex:1;font-size:13px;padding:6px 8px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary) }
-.wizard-ws-remove { font-size:11px;padding:2px 8px;border:0.5px solid var(--color-border-danger);border-radius:var(--border-radius-md);background:var(--color-background-danger);color:var(--color-text-danger);cursor:pointer }
+.wizard-ws-remove { font-size:11px;padding:2px 8px;border:0.5px solid var(--color-border-danger);border-radius:var(--border-radius-md);background:var(--color-background-danger);color:var(--color-text-danger);cursor:pointer;flex-shrink:0 }
 .wizard-add-ws { font-size:11px;padding:4px 10px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-secondary);cursor:pointer;margin-top:4px }
-.wizard-summary-row { font-size:12px;margin-bottom:8px }
-.wizard-summary-label { font-size:11px;font-weight:500;color:var(--color-text-secondary) }
-.wizard-summary-ws { display:flex;align-items:center;gap:8px;font-size:12px;margin-bottom:6px }
+.wizard-feat-row { border:0.5px solid var(--color-border-tertiary);border-radius:var(--border-radius-md);padding:8px;margin-bottom:8px }
+.wizard-feat-top { display:flex;gap:8px;margin-bottom:6px;align-items:center }
+.wizard-feat-top .wizard-feat-name { flex:1;font-size:13px;padding:5px 8px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary) }
+.wizard-feat-bottom { display:flex;align-items:center;gap:4px }
+.wizard-feat-bottom select { font-size:11px;padding:3px 4px;border:0.5px solid var(--color-border-secondary);border-radius:var(--border-radius-md);background:var(--color-background-primary);color:var(--color-text-primary);min-width:0 }
+.wizard-feat-ws { flex:2 }
+.wizard-feat-start,.wizard-feat-end { flex:1 }
+.wizard-feat-status { flex:2 }
+.wizard-arrow { font-size:10px;color:var(--color-text-tertiary);flex-shrink:0 }
+#wizard-feat-list { max-height:300px;overflow-y:auto;padding-right:2px }
+.wizard-summary-row { display:flex;gap:8px;font-size:12px;margin-bottom:8px }
+.wizard-summary-label { font-size:11px;font-weight:500;color:var(--color-text-secondary);min-width:90px }
+.wizard-summary-section { font-size:11px;font-weight:500;color:var(--color-text-secondary);margin:12px 0 6px }
+.wizard-summary-ws { display:flex;align-items:center;gap:8px;font-size:12px;margin-bottom:5px }
+.wizard-summary-dim { color:var(--color-text-tertiary);margin-left:4px }
 .wizard-ws-swatch { width:10px;height:10px;border-radius:50%;flex-shrink:0 }
 
 /* Roadmap selector */

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -1,57 +1,65 @@
+import { getConfig, refreshConfigFromStartDate } from './config.js';
 import { state, persistState } from './state.js';
 import { populateFilters } from './filters.js';
 import { render } from './render.js';
 
 const WIZARD_KEY = 'roadmap_wizard_done';
 
-let wizardWs   = [];
-let currentStep = 1;
-const TOTAL_STEPS = 3;
+let wizardStep     = 1;
+const TOTAL_STEPS  = 4;
+let wizardStartDate = '';
+let wizardWs       = [];
+let wizardFeatures = [];
 
 export function shouldShowWizard() {
   return !localStorage.getItem(WIZARD_KEY) && state.features.length === 0;
 }
 
 export function openWizard() {
-  wizardWs    = state.workstreams.map(ws => ({ ...ws }));
-  currentStep = 1;
+  wizardStartDate = state.ganttStartDate || '2026-02-01';
+  wizardWs        = state.workstreams.map(ws => ({ ...ws }));
+  wizardFeatures  = [];
+  wizardStep      = 1;
   renderWizardStep();
   document.getElementById('wizard-modal-bg').classList.add('open');
 }
 
-function closeWizard(markDone = true) {
+function closeWizard() {
   document.getElementById('wizard-modal-bg').classList.remove('open');
-  if (markDone) localStorage.setItem(WIZARD_KEY, '1');
+  localStorage.setItem(WIZARD_KEY, '1');
 }
 
 export function wizardSkip() {
-  closeWizard(true);
+  closeWizard();
 }
 
 export function wizardNext() {
-  if (currentStep === 1) {
+  if (wizardStep === 1) {
     const name = document.getElementById('wizard-roadmap-name').value.trim();
     if (!name) { document.getElementById('wizard-roadmap-name').focus(); return; }
+    const monthVal = document.getElementById('wizard-start-month').value;
+    if (!monthVal) { document.getElementById('wizard-start-month').focus(); return; }
     state.currentRoadmapName = name;
     const nameEl = document.getElementById('roadmap-name');
     if (nameEl) nameEl.value = name;
-  }
-  if (currentStep === 2) collectWizardWorkstreams();
-
-  if (currentStep < TOTAL_STEPS) {
-    currentStep++;
-    renderWizardStep();
-  } else {
+    wizardStartDate = monthVal + '-01';
+    refreshConfigFromStartDate(wizardStartDate);
+  } else if (wizardStep === 2) {
+    collectWizardWorkstreams();
+  } else if (wizardStep === 3) {
+    collectWizardFeatures();
+  } else if (wizardStep === TOTAL_STEPS) {
     finishWizard();
+    return;
   }
+  wizardStep++;
+  renderWizardStep();
 }
 
 export function wizardBack() {
-  if (currentStep === 2) collectWizardWorkstreams();
-  if (currentStep > 1) {
-    currentStep--;
-    renderWizardStep();
-  }
+  if (wizardStep === 2) collectWizardWorkstreams();
+  if (wizardStep === 3) collectWizardFeatures();
+  if (wizardStep > 1) { wizardStep--; renderWizardStep(); }
 }
 
 function collectWizardWorkstreams() {
@@ -60,6 +68,16 @@ function collectWizardWorkstreams() {
     name:  row.querySelector('.wizard-ws-name').value.trim(),
     color: row.querySelector('.wizard-ws-color').value,
   })).filter(ws => ws.name);
+}
+
+function collectWizardFeatures() {
+  wizardFeatures = Array.from(document.querySelectorAll('.wizard-feat-row')).map(row => ({
+    name:   row.querySelector('.wizard-feat-name').value.trim(),
+    ws:     row.querySelector('.wizard-feat-ws').value,
+    start:  parseInt(row.querySelector('.wizard-feat-start').value),
+    end:    parseInt(row.querySelector('.wizard-feat-end').value),
+    status: row.querySelector('.wizard-feat-status').value,
+  })).filter(f => f.name);
 }
 
 export function wizardAddWorkstream() {
@@ -76,18 +94,57 @@ export function wizardRemoveWorkstream(idx) {
   renderWizardStep();
 }
 
+export function wizardAddFeature() {
+  collectWizardFeatures();
+  const ws = wizardWs.find(w => w.name) || wizardWs[0];
+  wizardFeatures.push({ name: '', ws: ws?.id || '', start: 0, end: 0, status: 'not-started' });
+  renderWizardStep();
+  const rows = document.querySelectorAll('.wizard-feat-row');
+  rows[rows.length - 1]?.querySelector('.wizard-feat-name')?.focus();
+}
+
+export function wizardRemoveFeature(idx) {
+  collectWizardFeatures();
+  wizardFeatures.splice(idx, 1);
+  renderWizardStep();
+}
+
 function finishWizard() {
-  collectWizardWorkstreams();
-  if (wizardWs.length === 0) {
-    wizardWs = [{ id: 'general', name: 'General', color: '#4A6FA5' }];
-  }
-  state.workstreams = wizardWs;
-  state.features    = [];
-  state.nextId      = 1;
+  if (wizardWs.length === 0) wizardWs = [{ id: 'general', name: 'General', color: '#4A6FA5' }];
+  state.ganttStartDate = wizardStartDate;
+  state.workstreams    = wizardWs;
+  state.features       = wizardFeatures.map((f, i) => ({
+    id:     i + 1,
+    ws:     f.ws,
+    name:   f.name,
+    start:  Math.min(f.start, f.end),
+    end:    Math.max(f.start, f.end),
+    status: f.status,
+  }));
+  state.nextId = state.features.length + 1;
+  refreshConfigFromStartDate(wizardStartDate);
   populateFilters();
   render();
   persistState();
-  closeWizard(true);
+  closeWizard();
+}
+
+function monthOptions(selectedIdx) {
+  return getConfig().months.map((m, i) =>
+    `<option value="${i}"${i === selectedIdx ? ' selected' : ''}>${m}</option>`
+  ).join('');
+}
+
+function wsOptions(selectedId) {
+  return wizardWs.filter(w => w.name).map(w =>
+    `<option value="${w.id}"${w.id === selectedId ? ' selected' : ''}>${w.name}</option>`
+  ).join('');
+}
+
+function statusOptions(selectedId) {
+  return getConfig().statuses.map(s =>
+    `<option value="${s.id}"${s.id === selectedId ? ' selected' : ''}>${s.label}</option>`
+  ).join('');
 }
 
 function renderWizardStep() {
@@ -97,24 +154,28 @@ function renderWizardStep() {
   const backBtn = document.getElementById('wizard-back-btn');
   const nextBtn = document.getElementById('wizard-next-btn');
 
-  stepEl.textContent      = `Step ${currentStep} of ${TOTAL_STEPS}`;
-  backBtn.style.display   = currentStep > 1 ? 'inline-block' : 'none';
-  nextBtn.textContent     = currentStep === TOTAL_STEPS ? 'Finish' : 'Next →';
+  stepEl.textContent    = `Step ${wizardStep} of ${TOTAL_STEPS}`;
+  backBtn.style.display = wizardStep > 1 ? 'inline-block' : 'none';
+  nextBtn.textContent   = wizardStep === TOTAL_STEPS ? 'Finish' : 'Next →';
 
-  if (currentStep === 1) {
+  if (wizardStep === 1) {
     title.textContent = 'Name your roadmap';
     content.innerHTML = `
-      <p class="wizard-desc">Give this roadmap a name — typically the customer or project it covers.</p>
+      <p class="wizard-desc">Give this roadmap a name and set when the timeline starts.</p>
       <div class="form-row">
         <label>Roadmap name</label>
         <input type="text" id="wizard-roadmap-name"
           placeholder="e.g. Acme Corp Deployment"
-          value="${state.currentRoadmapName && state.currentRoadmapName !== 'My Roadmap' ? state.currentRoadmapName : ''}" />
+          value="${state.currentRoadmapName !== 'My Roadmap' ? state.currentRoadmapName : ''}" />
+      </div>
+      <div class="form-row">
+        <label>Timeline start</label>
+        <input type="month" id="wizard-start-month" value="${wizardStartDate.slice(0, 7)}" />
       </div>
     `;
     setTimeout(() => document.getElementById('wizard-roadmap-name')?.focus(), 50);
 
-  } else if (currentStep === 2) {
+  } else if (wizardStep === 2) {
     title.textContent = 'Define your workstreams';
     content.innerHTML = `
       <p class="wizard-desc">Workstreams are the swim lanes in your Gantt. Edit the defaults or add your own.</p>
@@ -132,28 +193,69 @@ function renderWizardStep() {
       <button class="wizard-add-ws" onclick="wizardAddWorkstream()">+ Add workstream</button>
     `;
 
-  } else if (currentStep === 3) {
-    const validWs = wizardWs.filter(ws => ws.name);
+  } else if (wizardStep === 3) {
+    title.textContent = 'Add initial features';
+    content.innerHTML = `
+      <p class="wizard-desc">Optionally add features now. You can always add more later from the toolbar.</p>
+      <div id="wizard-feat-list">
+        ${wizardFeatures.length === 0
+          ? '<p class="wizard-empty">No features yet — click below to add one.</p>'
+          : wizardFeatures.map((f, i) => `
+            <div class="wizard-feat-row">
+              <div class="wizard-feat-top">
+                <input type="text" class="wizard-feat-name" placeholder="Feature name" value="${f.name}" />
+                <button class="wizard-ws-remove" onclick="wizardRemoveFeature(${i})">✕</button>
+              </div>
+              <div class="wizard-feat-bottom">
+                <select class="wizard-feat-ws">${wsOptions(f.ws)}</select>
+                <select class="wizard-feat-start">${monthOptions(f.start)}</select>
+                <span class="wizard-arrow">→</span>
+                <select class="wizard-feat-end">${monthOptions(f.end)}</select>
+                <select class="wizard-feat-status">${statusOptions(f.status)}</select>
+              </div>
+            </div>
+          `).join('')}
+      </div>
+      <button class="wizard-add-ws" onclick="wizardAddFeature()">+ Add feature</button>
+    `;
+
+  } else if (wizardStep === 4) {
+    const cfg     = getConfig();
+    const validWs = wizardWs.filter(w => w.name);
     title.textContent = "You're all set!";
     content.innerHTML = `
-      <p class="wizard-desc">Here's what you've configured. Click <strong>Finish</strong> to open your roadmap.</p>
-      <div class="wizard-summary-row"><span class="wizard-summary-label">Roadmap</span>${state.currentRoadmapName}</div>
-      <div class="wizard-summary-label" style="margin:12px 0 6px">Workstreams</div>
+      <p class="wizard-desc">Here's a summary. Click <strong>Finish</strong> to open your roadmap.</p>
+      <div class="wizard-summary-row">
+        <span class="wizard-summary-label">Roadmap</span>${state.currentRoadmapName}
+      </div>
+      <div class="wizard-summary-row">
+        <span class="wizard-summary-label">Starts</span>${cfg.months[0]} ${wizardStartDate.slice(0, 4)}
+      </div>
+      <div class="wizard-summary-section">Workstreams</div>
       ${validWs.map(ws => `
         <div class="wizard-summary-ws">
           <div class="wizard-ws-swatch" style="background:${ws.color}"></div>
           <span>${ws.name}</span>
         </div>
       `).join('')}
-      <p class="wizard-desc" style="margin-top:16px">
-        Add features by clicking <strong>+ Add feature</strong> in the toolbar, or by clicking any cell in the chart.
-      </p>
+      ${wizardFeatures.length > 0 ? `
+        <div class="wizard-summary-section">Features (${wizardFeatures.length})</div>
+        ${wizardFeatures.map(f => {
+          const ws = validWs.find(w => w.id === f.ws);
+          return `<div class="wizard-summary-ws">
+            <div class="wizard-ws-swatch" style="background:${ws?.color || '#ccc'}"></div>
+            <span>${f.name}
+              <span class="wizard-summary-dim">${cfg.months[f.start]}–${cfg.months[f.end]}</span>
+            </span>
+          </div>`;
+        }).join('')}
+      ` : '<p class="wizard-empty" style="margin-top:8px">No features — add them from the toolbar.</p>'}
     `;
   }
 }
 
 export function initWizard() {
   document.getElementById('wizard-modal-bg').addEventListener('keydown', e => {
-    if (e.key === 'Enter' && currentStep !== 2) wizardNext();
+    if (e.key === 'Enter' && wizardStep !== 2 && wizardStep !== 3) wizardNext();
   });
 }


### PR DESCRIPTION
## Summary
**Step 1 — Name + start date**
- Roadmap name input
- Month picker sets the Gantt timeline start; drives the months array dynamically

**Step 2 — Workstreams**
- Edit name and color, add/remove rows

**Step 3 — Features**
- Add initial features with name, workstream, start month, end month, status
- Scrollable list if many features

**Step 4 — Summary**
- Shows name, timeline start, workstreams, and all features before committing

**Other changes**
- `state.ganttStartDate` persisted to localStorage
- `refreshConfigFromStartDate()` regenerates the months array and currentMonth highlight on every load
- `initState()` restores ganttStartDate and calls refresh before first render

## Test plan
- [ ] Clear localStorage, reload — wizard appears
- [ ] Step 1: name + month required; Next disabled without both
- [ ] Step 2: add/remove/recolor workstreams
- [ ] Step 3: add features, verify month dropdowns show correct month names for chosen start date
- [ ] Step 4: summary is accurate
- [ ] Finish: Gantt renders with correct timeline start and all configured items
- [ ] Skip: wizard closes, never re-appears
- [ ] Reload: ganttStartDate restored, months array correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)