### PR TITLE
fix: Show wizard in fresh sessions with no persisted state

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -62,6 +62,10 @@ export function exportStateAsJson() {
   URL.revokeObjectURL(url);
 }
 
+export function hasPersistedState() {
+  return !!localStorage.getItem(LOCAL_KEY);
+}
+
 export function importStateFromJson(file) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -1,5 +1,5 @@
 import { getConfig, refreshConfigFromStartDate } from './config.js';
-import { state, persistState } from './state.js';
+import { state, persistState, hasPersistedState } from './state.js';
 import { populateFilters } from './filters.js';
 import { render } from './render.js';
 
@@ -12,7 +12,7 @@ let wizardWs       = [];
 let wizardFeatures = [];
 
 export function shouldShowWizard() {
-  return !localStorage.getItem(WIZARD_KEY) && state.features.length === 0;
+  return !localStorage.getItem(WIZARD_KEY) && !hasPersistedState();
 }
 
 export function openWizard() {


### PR DESCRIPTION
The `shouldShowWizard()` check was `state.features.length === 0`, but the default `state` object always has 6 sample features. In an incognito window with empty localStorage, `initState()` leaves the defaults in place and the condition never fired.

Fix: check `hasPersistedState()` (new helper that looks for the localStorage key) instead of inspecting the in-memory feature array. Wizard now shows correctly whenever:
- No `WIZARD_KEY` in localStorage (wizard never completed or skipped), AND
- No `roadmap_local_data` in localStorage (no saved roadmap data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)