### PR TITLE
feat: Phase 2 — stats bar, collapsible workstreams, inline rename

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
       <option value="">All statuses</option>
     </select>
     <div style="flex:1"></div>
+    <button id="density-btn" onclick="toggleDensity()">Compact</button>
     <button onclick="exportToPptx()">⬇ Export .pptx</button>
     <button id="btn-google-slides" onclick="exportToGoogleSlides()">Export to Google Slides ↗</button>
   </div>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,9 @@
     <button id="theme-toggle-btn" onclick="toggleTheme()" title="Switch theme" style="padding:5px 8px;font-size:14px;line-height:1">☀︎</button>
   </div>
 
+  <!-- Stats bar -->
+  <div class="stats-bar" id="stats-bar"></div>
+
   <!-- Main toolbar -->
   <div class="toolbar">
     <button class="primary" onclick="openAddFeature()">+ Add feature</button>

--- a/src/filters.js
+++ b/src/filters.js
@@ -1,5 +1,6 @@
 import { getConfig } from './config.js';
-import { state } from './state.js';
+import { state, } from './state.js';
+import { isDark } from './render.js';
 
 export function populateFilters() {
   const cfg = getConfig();
@@ -12,10 +13,12 @@ export function populateFilters() {
 }
 
 export function renderLegend() {
-  const cfg = getConfig();
-  document.getElementById('legend').innerHTML = cfg.statuses.map(s =>
-    `<div class="legend-item">
-      <div class="legend-dot" style="background:${s.color}"></div>${s.label}
-    </div>`
-  ).join('');
+  const cfg  = getConfig();
+  const dark = isDark();
+  document.getElementById('legend').innerHTML = cfg.statuses.map(s => {
+    const fill = dark ? (s.darkFill || s.fill) : s.fill;
+    return `<div class="legend-item">
+      <div class="legend-dot" style="background:${fill}"></div>${s.label}
+    </div>`;
+  }).join('');
 }

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -2,8 +2,11 @@ import { getConfig } from './config.js';
 import { state, persistState } from './state.js';
 import { render } from './render.js';
 
-let resizing = null;
-let barDrag  = null;
+const LABEL_W_KEY = 'roadmap_label_w';
+
+let resizing    = null;
+let barDrag     = null;
+let labelResize = null;
 
 export function cellClick(fid, mi) {
   const f = state.features.find(x => x.id === fid);
@@ -85,6 +88,43 @@ function stopBarDrag() {
   } else {
     window.openEdit(fid);
   }
+}
+
+// ── Label column resize ───────────────────────────────────────────────────────
+
+export function startLabelResize(e) {
+  e.preventDefault();
+  const cfg = getConfig();
+  labelResize = { startX: e.clientX, origWidth: cfg.labelWidth };
+  document.body.classList.add('is-dragging');
+  document.addEventListener('mousemove', doLabelResize);
+  document.addEventListener('mouseup', stopLabelResize);
+}
+
+function doLabelResize(e) {
+  if (!labelResize) return;
+  const cfg = getConfig();
+  const newWidth = Math.max(120, Math.min(400, labelResize.origWidth + (e.clientX - labelResize.startX)));
+  cfg.labelWidth = newWidth;
+  document.documentElement.style.setProperty('--label-w', newWidth + 'px');
+}
+
+function stopLabelResize() {
+  if (!labelResize) return;
+  document.removeEventListener('mousemove', doLabelResize);
+  document.removeEventListener('mouseup', stopLabelResize);
+  document.body.classList.remove('is-dragging');
+  labelResize = null;
+  try { localStorage.setItem(LABEL_W_KEY, getConfig().labelWidth); } catch (_) {}
+}
+
+export function initLabelWidth() {
+  const cfg = getConfig();
+  try {
+    const saved = parseInt(localStorage.getItem(LABEL_W_KEY));
+    if (saved >= 120 && saved <= 400) cfg.labelWidth = saved;
+  } catch (_) {}
+  document.documentElement.style.setProperty('--label-w', cfg.labelWidth + 'px');
 }
 
 let rowDrag = null;

--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,8 @@ const THEME_KEY   = 'roadmap_theme';
 const THEMES      = ['gradient', 'gradient-dark'];
 const DENSITY_KEY = 'roadmap_density';
 
+let _appReady = false;
+
 function applyTheme(theme) {
   document.documentElement.setAttribute('data-theme', theme);
   localStorage.setItem(THEME_KEY, theme);
@@ -35,6 +37,7 @@ function applyTheme(theme) {
   if (logo) logo.src = (import.meta.env.BASE_URL || '/') + (theme === 'gradient-dark' ? 'logo-white.svg' : 'logo-black.svg');
   const btn = document.getElementById('theme-toggle-btn');
   if (btn) btn.textContent = theme === 'gradient-dark' ? '☽' : '☀︎';
+  if (_appReady) { renderLegend(); render(); }
 }
 
 function toggleTheme() {
@@ -108,6 +111,7 @@ async function init() {
   renderLegend();
   render();
   applyDensity(localStorage.getItem(DENSITY_KEY) || 'comfortable');
+  _appReady = true;
   if (shouldShowWizard()) openWizard();
 
   // Wire up roadmap name input

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import {
 } from './modals.js';
 import {
   startResize, doResize, stopResize, rowDragMouseDown, cellClick, startBarDrag,
+  startLabelResize, initLabelWidth,
 } from './interactions.js';
 import { exportToPptx } from './export/exportPptx.js';
 import { exportToGoogleSlides } from './export/exportGoogleSlides.js';
@@ -23,8 +24,9 @@ import {
 import { toggleWsCollapse, startWsRename } from './render.js';
 import { refreshConfigFromStartDate } from './config.js';
 
-const THEME_KEY = 'roadmap_theme';
-const THEMES    = ['gradient', 'gradient-dark'];
+const THEME_KEY   = 'roadmap_theme';
+const THEMES      = ['gradient', 'gradient-dark'];
+const DENSITY_KEY = 'roadmap_density';
 
 function applyTheme(theme) {
   document.documentElement.setAttribute('data-theme', theme);
@@ -41,7 +43,21 @@ function toggleTheme() {
   applyTheme(next);
 }
 
-Object.assign(window, { toggleTheme });
+function applyDensity(density) {
+  const gantt = document.getElementById('gantt');
+  if (!gantt) return;
+  gantt.classList.toggle('compact', density === 'compact');
+  localStorage.setItem(DENSITY_KEY, density);
+  const btn = document.getElementById('density-btn');
+  if (btn) btn.textContent = density === 'compact' ? 'Comfortable' : 'Compact';
+}
+
+function toggleDensity() {
+  const gantt = document.getElementById('gantt');
+  applyDensity(gantt?.classList.contains('compact') ? 'comfortable' : 'compact');
+}
+
+Object.assign(window, { toggleTheme, toggleDensity });
 import {
   initAuth, isConfigured, showSignIn, signOut, submitSignIn,
   loadRoadmap, saveRoadmap, newRoadmap, confirmNewRoadmap, subscribeRealtime,
@@ -60,6 +76,7 @@ Object.assign(window, {
   wizardAddWorkstream, wizardRemoveWorkstream,
   wizardAddFeature, wizardRemoveFeature,
   toggleWsCollapse, startWsRename,
+  startLabelResize,
   handleRoadmapSelect: async (e) => {
     const id = e.target.value;
     if (id) {
@@ -83,12 +100,14 @@ async function init() {
   await initConfig();
   initState();
   if (state.ganttStartDate) refreshConfigFromStartDate(state.ganttStartDate);
+  initLabelWidth();
   await initAuth();
   initModals();
   initWizard();
   populateFilters();
   renderLegend();
   render();
+  applyDensity(localStorage.getItem(DENSITY_KEY) || 'comfortable');
   if (shouldShowWizard()) openWizard();
 
   // Wire up roadmap name input

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ import {
   wizardAddWorkstream, wizardRemoveWorkstream,
   wizardAddFeature, wizardRemoveFeature,
 } from './wizard.js';
+import { toggleWsCollapse, startWsRename } from './render.js';
 import { refreshConfigFromStartDate } from './config.js';
 
 const THEME_KEY = 'roadmap_theme';
@@ -58,6 +59,7 @@ Object.assign(window, {
   openWizard, wizardNext, wizardBack, wizardSkip,
   wizardAddWorkstream, wizardRemoveWorkstream,
   wizardAddFeature, wizardRemoveFeature,
+  toggleWsCollapse, startWsRename,
   handleRoadmapSelect: async (e) => {
     const id = e.target.value;
     if (id) {

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,5 @@
 import { getConfig } from './config.js';
-import { state } from './state.js';
+import { state, persistState } from './state.js';
 
 export function statusFor(id) {
   const cfg = getConfig();
@@ -11,7 +11,91 @@ function gridCols() {
   return `${cfg.labelWidth}px ${cfg.months.map(() => cfg.colWidth + 'px').join(' ')}`;
 }
 
+const _collapsed = new Set();
+
+export function toggleWsCollapse(wsId) {
+  if (_collapsed.has(wsId)) _collapsed.delete(wsId);
+  else _collapsed.add(wsId);
+  render();
+}
+
+export function startWsRename(wsId) {
+  const header = document.querySelector(`.ws-header[data-wsid="${wsId}"]`);
+  if (!header) return;
+  const nameEl = header.querySelector('.ws-name');
+  if (!nameEl || nameEl.querySelector('input')) return;
+
+  const ws = state.workstreams.find(w => w.id === wsId);
+  if (!ws) return;
+
+  const input = document.createElement('input');
+  input.className = 'ws-name-inline';
+  input.value = ws.name;
+  nameEl.textContent = '';
+  nameEl.appendChild(input);
+  input.focus();
+  input.select();
+
+  let saved = false;
+
+  function save() {
+    if (saved) return;
+    saved = true;
+    const val = input.value.trim();
+    if (val && val !== ws.name) {
+      ws.name = val;
+      persistState();
+    }
+    render();
+  }
+
+  function cancel() {
+    if (saved) return;
+    saved = true;
+    render();
+  }
+
+  input.addEventListener('blur', save);
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); save(); }
+    if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+  });
+}
+
+function renderStatsBar() {
+  const el = document.getElementById('stats-bar');
+  if (!el) return;
+  const cfg = getConfig();
+  const total = state.features.length;
+  if (total === 0) { el.innerHTML = ''; return; }
+
+  const deployedCount = state.features.filter(f => f.status === 'deployed').length;
+  const pct = Math.round((deployedCount / total) * 100);
+
+  const statusCounts = {};
+  state.features.forEach(f => { statusCounts[f.status] = (statusCounts[f.status] || 0) + 1; });
+
+  const pills = cfg.statuses
+    .filter(s => statusCounts[s.id])
+    .map(s => `<span class="stats-pill" style="background:${s.fill};color:${s.color}">${s.label} <b>${statusCounts[s.id]}</b></span>`)
+    .join('');
+
+  el.innerHTML = `
+    <div class="stats-deploy">
+      <span class="stats-pct">${pct}%</span>
+      <span class="stats-label">deployed</span>
+    </div>
+    <div class="stats-track-wrap" title="${deployedCount} of ${total} features deployed">
+      <div class="stats-track"><div class="stats-track-fill" style="width:${pct}%"></div></div>
+    </div>
+    <span class="stats-count">${total} feature${total !== 1 ? 's' : ''}</span>
+    <div class="stats-pills">${pills}</div>
+  `;
+}
+
 export function render() {
+  renderStatsBar();
+
   const cfg = getConfig();
   const filterWs = document.getElementById('filterWs').value;
   const filterSt = document.getElementById('filterStatus').value;
@@ -44,44 +128,48 @@ export function render() {
   state.workstreams.forEach(ws => {
     if (filterWs && ws.id !== filterWs) return;
     const wsFeatures = state.features.filter(f => f.ws === ws.id && (!filterSt || f.status === filterSt));
+    const collapsed = _collapsed.has(ws.id);
 
     html += `<div class="ws-section">`;
     html += `<div class="ws-header" data-wsid="${ws.id}">
+      <button class="ws-collapse-btn${collapsed ? ' collapsed' : ''}" onclick="toggleWsCollapse('${ws.id}')" aria-expanded="${!collapsed}" title="${collapsed ? 'Expand' : 'Collapse'}">▾</button>
       <div class="ws-dot" style="background:${ws.color}"></div>
-      <div class="ws-name">${ws.name}</div>
+      <div class="ws-name" ondblclick="startWsRename('${ws.id}')" title="Double-click to rename">${ws.name}</div>
       <div class="ws-actions">
         <button onclick="openAddFeature('${ws.id}')">+ feature</button>
         <button onclick="openEditWorkstream('${ws.id}')">edit</button>
       </div>
     </div>`;
 
-    wsFeatures.forEach(f => {
-      const st = statusFor(f.status);
-      html += `<div class="feature-row" data-fid="${f.id}" style="display:grid;grid-template-columns:${gridCols()}">`;
+    if (!collapsed) {
+      wsFeatures.forEach(f => {
+        const st = statusFor(f.status);
+        html += `<div class="feature-row" data-fid="${f.id}" style="display:grid;grid-template-columns:${gridCols()}">`;
 
-      html += `<div class="feature-label">
-        <span class="drag-handle" onmousedown="rowDragMouseDown(event,${f.id})">⠿</span>
-        <span onclick="openEdit(${f.id})" style="cursor:pointer">${f.name}</span>
-      </div>`;
+        html += `<div class="feature-label">
+          <span class="drag-handle" onmousedown="rowDragMouseDown(event,${f.id})">⠿</span>
+          <span onclick="openEdit(${f.id})" style="cursor:pointer">${f.name}</span>
+        </div>`;
 
-      cfg.months.forEach((_, i) => {
-        const isStart = i === f.start;
-        const totalW = (f.end - f.start + 1) * cfg.colWidth - 8;
-        html += `<div class="cell${i % 2 ? ' alt' : ''}" onclick="cellClick(${f.id},${i})">`;
-        if (isStart) {
-          const grips = `<span class="grip-dot"></span><span class="grip-dot"></span><span class="grip-dot"></span>`;
-          html += `<div class="bar"
-            style="left:4px;width:${totalW}px;background:${st.fill};color:${st.color}"
-            onmousedown="startBarDrag(event,${f.id})">
-            <div class="bar-resize-l" onmousedown="startResize(event,${f.id},'l')">${grips}</div>
-            <span style="flex:1;overflow:hidden;text-overflow:ellipsis;pointer-events:none;padding:0 2px">${f.name}</span>
-            <div class="bar-resize-r" onmousedown="startResize(event,${f.id},'r')">${grips}</div>
-          </div>`;
-        }
+        cfg.months.forEach((_, i) => {
+          const isStart = i === f.start;
+          const totalW = (f.end - f.start + 1) * cfg.colWidth - 8;
+          html += `<div class="cell${i % 2 ? ' alt' : ''}" onclick="cellClick(${f.id},${i})">`;
+          if (isStart) {
+            const grips = `<span class="grip-dot"></span><span class="grip-dot"></span><span class="grip-dot"></span>`;
+            html += `<div class="bar"
+              style="left:4px;width:${totalW}px;background:${st.fill};color:${st.color}"
+              onmousedown="startBarDrag(event,${f.id})">
+              <div class="bar-resize-l" onmousedown="startResize(event,${f.id},'l')">${grips}</div>
+              <span style="flex:1;overflow:hidden;text-overflow:ellipsis;pointer-events:none;padding:0 2px">${f.name}</span>
+              <div class="bar-resize-r" onmousedown="startResize(event,${f.id},'r')">${grips}</div>
+            </div>`;
+          }
+          html += '</div>';
+        });
         html += '</div>';
       });
-      html += '</div>';
-    });
+    }
 
     html += '</div>';
   });

--- a/src/render.js
+++ b/src/render.js
@@ -6,6 +6,13 @@ export function statusFor(id) {
   return cfg.statuses.find(s => s.id === id) || cfg.statuses[cfg.statuses.length - 1];
 }
 
+export function isDark() {
+  return document.documentElement.getAttribute('data-theme') === 'gradient-dark';
+}
+
+function barFill(st)  { return isDark() ? (st.darkFill  || st.fill)  : st.fill; }
+function barColor(st) { return isDark() ? (st.darkColor || st.color) : st.color; }
+
 function gridCols() {
   const cfg = getConfig();
   return `var(--label-w) ${cfg.months.map(() => cfg.colWidth + 'px').join(' ')}`;
@@ -75,9 +82,14 @@ function renderStatsBar() {
   const statusCounts = {};
   state.features.forEach(f => { statusCounts[f.status] = (statusCounts[f.status] || 0) + 1; });
 
+  const dark = isDark();
   const pills = cfg.statuses
     .filter(s => statusCounts[s.id])
-    .map(s => `<span class="stats-pill" style="background:${s.fill};color:${s.color}">${s.label} <b>${statusCounts[s.id]}</b></span>`)
+    .map(s => {
+      const bg  = dark ? (s.darkFill  || s.fill)  : s.fill;
+      const clr = dark ? (s.darkColor || s.color) : s.color;
+      return `<span class="stats-pill" style="background:${bg};color:${clr}">${s.label} <b>${statusCounts[s.id]}</b></span>`;
+    })
     .join('');
 
   el.innerHTML = `
@@ -158,7 +170,7 @@ export function render() {
           if (isStart) {
             const grips = `<span class="grip-dot"></span><span class="grip-dot"></span><span class="grip-dot"></span>`;
             html += `<div class="bar"
-              style="left:4px;width:${totalW}px;background:${st.fill};color:${st.color}"
+              style="left:4px;width:${totalW}px;background:${barFill(st)};color:${barColor(st)}"
               onmousedown="startBarDrag(event,${f.id})">
               <div class="bar-resize-l" onmousedown="startResize(event,${f.id},'l')">${grips}</div>
               <span style="flex:1;overflow:hidden;text-overflow:ellipsis;pointer-events:none;padding:0 2px">${f.name}</span>

--- a/src/render.js
+++ b/src/render.js
@@ -8,7 +8,7 @@ export function statusFor(id) {
 
 function gridCols() {
   const cfg = getConfig();
-  return `${cfg.labelWidth}px ${cfg.months.map(() => cfg.colWidth + 'px').join(' ')}`;
+  return `var(--label-w) ${cfg.months.map(() => cfg.colWidth + 'px').join(' ')}`;
 }
 
 const _collapsed = new Set();
@@ -118,7 +118,7 @@ export function render() {
 
   // Month header row
   html += `<div class="gantt-header" style="display:grid;grid-template-columns:${gridCols()}">`;
-  html += `<div class="month-cell" style="text-align:left;padding-left:10px">Workstream / Feature</div>`;
+  html += `<div class="month-cell label-col-header" style="text-align:left;padding-left:10px">Workstream / Feature<div class="label-col-resizer" onmousedown="startLabelResize(event)"></div></div>`;
   cfg.months.forEach((m, i) => {
     html += `<div class="month-cell${i === cfg.currentMonth ? ' current' : ''}">${m}</div>`;
   });

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -394,6 +394,22 @@ body.is-dragging .bar, body.is-dragging .bar * { pointer-events:none }
 .ws-collapse-btn:hover { background:var(--bg-3);color:var(--text) }
 .ws-collapse-btn.collapsed { transform:rotate(-90deg) }
 
+/* ── Label column resizer ────────────────────────────────────────────────────── */
+.label-col-header { position:relative; overflow:visible !important }
+.label-col-resizer {
+  position:absolute;top:0;right:0;bottom:0;width:6px;
+  cursor:col-resize;z-index:3;
+}
+.label-col-resizer::after {
+  content:'';position:absolute;top:20%;right:1px;bottom:20%;
+  width:2px;border-radius:1px;background:var(--border);opacity:0;transition:opacity .15s;
+}
+.label-col-header:hover .label-col-resizer::after { opacity:1 }
+
+/* ── Row density ─────────────────────────────────────────────────────────────── */
+.gantt.compact .feature-row { min-height:28px }
+.gantt.compact .bar { top:4px;bottom:4px }
+
 /* ── Inline workstream rename ────────────────────────────────────────────────── */
 .ws-name-inline {
   font-weight:600;font-size:12px;color:var(--text);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -353,3 +353,52 @@ body.is-dragging .bar, body.is-dragging .bar * { pointer-events:none }
 
 /* ── Save status ─────────────────────────────────────────────────────────────── */
 #save-status { font-size:11px;font-family:var(--font-body) }
+
+/* ── Stats bar ───────────────────────────────────────────────────────────────── */
+.stats-bar {
+  display:flex;align-items:center;gap:14px;
+  padding:10px 20px;border-bottom:1px solid var(--border-2);
+  background:var(--bg);min-height:44px;
+}
+.stats-deploy { display:flex;align-items:baseline;gap:5px }
+.stats-pct {
+  font-family:var(--font-display);font-size:20px;font-weight:500;
+  color:var(--text);line-height:1;
+}
+.stats-label { font-size:11px;color:var(--text-3);font-family:var(--font-body) }
+.stats-track-wrap { display:flex;align-items:center }
+.stats-track {
+  width:120px;height:5px;border-radius:3px;
+  background:var(--bg-3);overflow:hidden;
+}
+.stats-track-fill {
+  height:100%;border-radius:3px;
+  background:#00db9a;transition:width .4s ease;
+}
+.stats-count { font-size:11px;color:var(--text-3);font-family:var(--font-body);white-space:nowrap }
+.stats-pills { display:flex;flex-wrap:wrap;gap:5px;margin-left:4px }
+.stats-pill {
+  font-size:10px;font-family:var(--font-body);font-weight:500;
+  padding:2px 7px;border-radius:10px;white-space:nowrap;
+}
+.stats-pill b { font-weight:600 }
+
+/* ── Collapsible workstream ──────────────────────────────────────────────────── */
+.ws-collapse-btn {
+  display:flex;align-items:center;justify-content:center;
+  width:18px;height:18px;flex-shrink:0;
+  background:transparent;border:none;padding:0;
+  color:var(--text-3);cursor:pointer;font-size:13px;line-height:1;
+  transition:transform .15s ease;border-radius:3px;
+}
+.ws-collapse-btn:hover { background:var(--bg-3);color:var(--text) }
+.ws-collapse-btn.collapsed { transform:rotate(-90deg) }
+
+/* ── Inline workstream rename ────────────────────────────────────────────────── */
+.ws-name-inline {
+  font-weight:600;font-size:12px;color:var(--text);
+  font-family:var(--font-body);letter-spacing:-.01em;
+  background:var(--bg);border:1px solid var(--accent-2);
+  border-radius:var(--radius);padding:1px 5px;
+  outline:none;min-width:80px;
+}


### PR DESCRIPTION
## Summary

- **Stats bar**: New component between top bar and toolbar showing deployed %, animated green progress track, feature count, and status pills (filtered to statuses with ≥1 feature)
- **Collapsible workstreams**: Chevron button on every workstream header — rotates when collapsed, hides all feature rows; state tracked per workstream ID
- **Inline workstream rename**: Double-click a workstream name to edit in place; Enter/blur saves, Escape cancels, blue focus ring on the input

## Test plan

- [ ] Stats bar shows correct deployed % and updates as features change status
- [ ] Progress track animates when % changes
- [ ] Status pills only appear for statuses with at least one feature
- [ ] Clicking chevron collapses/expands feature rows; chevron rotates
- [ ] Collapsing one workstream does not affect others
- [ ] Double-click workstream name → input appears, auto-focused
- [ ] Enter saves new name; name updates in header and filter dropdown
- [ ] Escape cancels without changing the name
- [ ] Blur (click away) also saves

🤖 Generated with [Claude Code](https://claude.com/claude-code)