### PR TITLE
feat: Replace custom Gantt renderer with vis-timeline (closes #31)

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,8 +53,11 @@
   <!-- Legend -->
   <div class="legend" id="legend"></div>
 
-  <!-- Gantt grid -->
-  <div class="gantt-wrap"><div class="gantt" id="gantt"></div></div>
+  <!-- Release band header (aligned with vis-timeline label panel + month columns) -->
+  <div class="gantt-wrap">
+    <div class="gantt-release-header" id="release-header"></div>
+    <div id="gantt"></div>
+  </div>
 
   <!-- Feature modal -->
   <div class="modal-bg" id="modal-bg">

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,23 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.45.0",
-        "pptxgenjs": "^3.12.0"
+        "pptxgenjs": "^3.12.0",
+        "vis-timeline": "^8.5.0"
       },
       "devDependencies": {
         "vite": "^5.4.0"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "peer": true,
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -849,6 +862,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "peer": true
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -867,11 +886,32 @@
         "@types/node": "*"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "peer": true
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -987,6 +1027,12 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/keycharm": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.4.0.tgz",
+      "integrity": "sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==",
+      "peer": true
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -994,6 +1040,15 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/nanoid": {
@@ -1089,6 +1144,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/propagating-hammerjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-3.0.0.tgz",
+      "integrity": "sha512-FJTclGll0ysatpF9rKO4jwobyaVDitPb0g/bGlufqqtXPQX8mxf8IXilnIK2iYRMPkVlYeFNhPTrspF9CM1stg==",
+      "peer": true,
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.17"
+      }
     },
     "node_modules/queue": {
       "version": "6.0.2",
@@ -1208,6 +1272,70 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "peer": true,
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vis-data": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-8.0.3.tgz",
+      "integrity": "sha512-jhnb6rJNqkKR1Qmlay0VuDXY9ZlvAnYN1udsrP4U+krgZEq7C0yNSKdZqmnCe13mdnf9AdVcdDGFOzy2mpPoqw==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "vis-util": ">=6.0.0"
+      }
+    },
+    "node_modules/vis-timeline": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/vis-timeline/-/vis-timeline-8.5.0.tgz",
+      "integrity": "sha512-u0+UUuk8qJTxf2SdQ0z0ckCjtks0ECRrjAipbmCZd6vEPf6USGXxeoi7ilRilTU8iVzVE3P0W5TLWzei5KuPfQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0",
+        "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
+        "moment": "^2.24.0",
+        "propagating-hammerjs": "^1.4.0 || ^2.0.0 || ^3.0.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "vis-data": ">=8.0.0",
+        "vis-util": ">=6.0.0",
+        "xss": "^1.0.0"
+      }
+    },
+    "node_modules/vis-util": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-6.0.0.tgz",
+      "integrity": "sha512-qtpts3HRma0zPe4bO7t9A2uejkRNj8Z2Tb6do6lN85iPNWExFkUiVhdAq5uLGIUqBFduyYeqWJKv/jMkxX0R5g==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0 || ^2.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
@@ -1287,6 +1415,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "peer": true,
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.0",
-    "pptxgenjs": "^3.12.0"
+    "pptxgenjs": "^3.12.0",
+    "vis-timeline": "^8.5.0"
   }
 }

--- a/src/gantt.js
+++ b/src/gantt.js
@@ -1,0 +1,176 @@
+import { Timeline } from 'vis-timeline/esnext';
+import { getConfig } from './config.js';
+import { state, persistState } from './state.js';
+import { statusFor, isDark } from './render.js';
+
+let _timeline = null;
+
+export function getTimeline() { return _timeline; }
+
+export function redrawGantt() {
+  if (_timeline) _timeline.redraw();
+}
+
+export function destroyGantt() {
+  if (_timeline) { _timeline.destroy(); _timeline = null; }
+}
+
+function monthToDate(idx) {
+  const cfg = getConfig();
+  const d = new Date(cfg.ganttStartDate + 'T00:00:00');
+  d.setMonth(d.getMonth() + idx);
+  return d;
+}
+
+function dateToMonthIdx(date) {
+  const cfg = getConfig();
+  const start = new Date(cfg.ganttStartDate + 'T00:00:00');
+  return (date.getFullYear() - start.getFullYear()) * 12 +
+    (date.getMonth() - start.getMonth());
+}
+
+function snapMonth(date) {
+  const d = new Date(date);
+  d.setDate(1);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function itemStyle(f) {
+  const st = statusFor(f.status);
+  const dark = isDark();
+  const bg  = dark ? (st.darkFill  || st.fill)  : st.fill;
+  const clr = dark ? (st.darkColor || st.color) : st.color;
+  return `background:${bg};color:${clr};border-color:transparent;`;
+}
+
+function buildItems(filterWs, filterSt, collapsed) {
+  const cfg = getConfig();
+  const arr = [];
+
+  // Current month highlight band
+  const cm = cfg.currentMonth;
+  if (cm >= 0 && cm < cfg.months.length) {
+    arr.push({
+      id: '__current__',
+      content: '',
+      start: monthToDate(cm),
+      end: monthToDate(cm + 1),
+      type: 'background',
+      className: 'vis-current-month',
+      selectable: false,
+    });
+  }
+
+  // Feature items
+  state.features.forEach(f => {
+    if (filterWs && f.ws !== filterWs) return;
+    if (filterSt && f.status !== filterSt) return;
+    if (collapsed.has(f.ws)) return;
+    arr.push({
+      id: f.id,
+      content: f.name,
+      start: monthToDate(f.start),
+      end: monthToDate(f.end + 1),
+      group: f.ws,
+      style: itemStyle(f),
+      className: 'vis-feature',
+      editable: { updateTime: true, updateGroup: true, remove: false },
+    });
+  });
+
+  return arr;
+}
+
+function buildGroups(filterWs, collapsed) {
+  return state.workstreams
+    .filter(ws => !filterWs || ws.id === filterWs)
+    .map((ws, i) => ({
+      id: ws.id,
+      order: i,
+      content: `<div class="vis-ws-header" data-wsid="${ws.id}">
+        <button class="ws-collapse-btn${collapsed.has(ws.id) ? ' collapsed' : ''}"
+          onclick="toggleWsCollapse('${ws.id}')"
+          aria-expanded="${!collapsed.has(ws.id)}"
+          title="${collapsed.has(ws.id) ? 'Expand' : 'Collapse'}">▾</button>
+        <div class="ws-dot" style="background:${ws.color}"></div>
+        <div class="ws-name" ondblclick="startWsRename('${ws.id}')" title="Double-click to rename">${ws.name}</div>
+        <div class="ws-actions">
+          <button onclick="openAddFeature('${ws.id}')">+ feature</button>
+          <button onclick="openEditWorkstream('${ws.id}')">edit</button>
+        </div>
+      </div>`,
+    }));
+}
+
+function addResizeHandle(container) {
+  const leftPanel = container.querySelector('.vis-panel.vis-left');
+  if (!leftPanel || leftPanel.querySelector('.label-col-resizer')) return;
+  const handle = document.createElement('div');
+  handle.className = 'label-col-resizer';
+  handle.addEventListener('mousedown', e => window.startLabelResize(e));
+  leftPanel.appendChild(handle);
+}
+
+export function initGantt(filterWs, filterSt, collapsed) {
+  const cfg = getConfig();
+  const container = document.getElementById('gantt');
+  if (!container) return;
+
+  const startDate = monthToDate(0);
+  const endDate   = monthToDate(cfg.months.length);
+  const itemArr   = buildItems(filterWs, filterSt, collapsed);
+  const groupArr  = buildGroups(filterWs, collapsed);
+
+  if (_timeline) {
+    _timeline.setItems(itemArr);
+    _timeline.setGroups(groupArr);
+    return;
+  }
+
+  const options = {
+    start: startDate,
+    end: endDate,
+    min: startDate,
+    max: endDate,
+    moveable: false,
+    zoomable: false,
+    showMajorLabels: false,
+    showMinorLabels: true,
+    timeAxis: { scale: 'month', step: 1 },
+    orientation: { axis: 'top' },
+    editable: { updateTime: true, updateGroup: true, remove: false },
+    snap: snapMonth,
+    selectable: true,
+    multiselect: false,
+    groupOrder: 'order',
+    margin: { item: { horizontal: 4, vertical: 4 }, axis: 4 },
+    format: { minorLabels: { month: 'MMM', year: '' } },
+    onMove(item, callback) {
+      const f = state.features.find(x => x.id === item.id);
+      if (!f) { callback(null); return; }
+      const cfg = getConfig();
+      const rawStart = dateToMonthIdx(item.start);
+      const rawEnd   = dateToMonthIdx(item.end) - 1;
+      const dur      = f.end - f.start;
+      f.start = Math.max(0, Math.min(cfg.months.length - 1, rawStart));
+      f.end   = Math.max(f.start, Math.min(cfg.months.length - 1, rawEnd >= rawStart ? rawEnd : f.start + dur));
+      f.ws    = String(item.group);
+      item.style = itemStyle(f);
+      persistState();
+      callback(item);
+    },
+  };
+
+  _timeline = new Timeline(container, itemArr, groupArr, options);
+
+  _timeline.on('select', props => {
+    const id = props.items[0];
+    if (typeof id === 'number') {
+      window.openEdit(id);
+      setTimeout(() => _timeline?.setSelection([]), 0);
+    }
+  });
+
+  requestAnimationFrame(() => addResizeHandle(container));
+}

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -1,94 +1,9 @@
 import { getConfig } from './config.js';
-import { state, persistState } from './state.js';
-import { render } from './render.js';
+import { redrawGantt } from './gantt.js';
 
 const LABEL_W_KEY = 'roadmap_label_w';
 
-let resizing    = null;
-let barDrag     = null;
 let labelResize = null;
-
-export function cellClick(fid, mi) {
-  const f = state.features.find(x => x.id === fid);
-  if (!f) return;
-  if (mi < f.start)    { f.start = mi; render(); persistState(); }
-  else if (mi > f.end) { f.end   = mi; render(); persistState(); }
-}
-
-export function startResize(e, fid, side) {
-  e.stopPropagation();
-  e.preventDefault();
-  resizing = { fid, side, startX: e.clientX, orig: { ...state.features.find(x => x.id === fid) } };
-  document.addEventListener('mousemove', doResize);
-  document.addEventListener('mouseup', stopResize);
-}
-
-export function doResize(e) {
-  if (!resizing) return;
-  const cfg = getConfig();
-  const dx = e.clientX - resizing.startX;
-  const dMonths = Math.round(dx / cfg.colWidth);
-  const f = state.features.find(x => x.id === resizing.fid);
-  if (!f) return;
-  if (resizing.side === 'r') {
-    f.end   = Math.min(cfg.months.length - 1, Math.max(f.start, resizing.orig.end   + dMonths));
-  } else {
-    f.start = Math.max(0, Math.min(f.end, resizing.orig.start + dMonths));
-  }
-  render();
-}
-
-export function stopResize() {
-  if (!resizing) return;
-  persistState();
-  resizing = null;
-  document.removeEventListener('mousemove', doResize);
-  document.removeEventListener('mouseup', stopResize);
-}
-
-// ── Bar drag (move entire bar horizontally) ───────────────────────────────────
-
-export function startBarDrag(e, fid) {
-  if (e.button !== 0) return;
-  e.stopPropagation();
-  e.preventDefault();
-  const f = state.features.find(x => x.id === fid);
-  if (!f) return;
-  barDrag = { fid, startX: e.clientX, orig: { start: f.start, end: f.end }, moved: false };
-  document.addEventListener('mousemove', doBarDrag);
-  document.addEventListener('mouseup', stopBarDrag);
-}
-
-function doBarDrag(e) {
-  if (!barDrag) return;
-  const dx = e.clientX - barDrag.startX;
-  if (!barDrag.moved && Math.abs(dx) < 5) return;
-  barDrag.moved = true;
-  document.body.classList.add('is-dragging');
-  const cfg = getConfig();
-  const dMonths = Math.round(dx / cfg.colWidth);
-  const f = state.features.find(x => x.id === barDrag.fid);
-  if (!f) return;
-  const duration = barDrag.orig.end - barDrag.orig.start;
-  const newStart = Math.max(0, Math.min(cfg.months.length - 1 - duration, barDrag.orig.start + dMonths));
-  f.start = newStart;
-  f.end   = newStart + duration;
-  render();
-}
-
-function stopBarDrag() {
-  if (!barDrag) return;
-  document.removeEventListener('mousemove', doBarDrag);
-  document.removeEventListener('mouseup', stopBarDrag);
-  document.body.classList.remove('is-dragging');
-  const { fid, moved } = barDrag;
-  barDrag = null;
-  if (moved) {
-    persistState();
-  } else {
-    window.openEdit(fid);
-  }
-}
 
 // ── Label column resize ───────────────────────────────────────────────────────
 
@@ -107,6 +22,7 @@ function doLabelResize(e) {
   const newWidth = Math.max(120, Math.min(400, labelResize.origWidth + (e.clientX - labelResize.startX)));
   cfg.labelWidth = newWidth;
   document.documentElement.style.setProperty('--label-w', newWidth + 'px');
+  redrawGantt();
 }
 
 function stopLabelResize() {
@@ -125,79 +41,4 @@ export function initLabelWidth() {
     if (saved >= 120 && saved <= 400) cfg.labelWidth = saved;
   } catch (_) {}
   document.documentElement.style.setProperty('--label-w', cfg.labelWidth + 'px');
-}
-
-let rowDrag = null;
-
-export function rowDragMouseDown(e, fid) {
-  if (e.button !== 0) return;
-  e.preventDefault();
-  const f = state.features.find(x => x.id === fid);
-  if (!f) return;
-  rowDrag = { fid, ws: f.ws, targetFid: null, targetWs: null };
-  document.body.classList.add('is-dragging');
-  document.addEventListener('mousemove', onRowDragMove);
-  document.addEventListener('mouseup', onRowDragUp);
-}
-
-function onRowDragMove(e) {
-  if (!rowDrag) return;
-  document.querySelectorAll('.dragging-over').forEach(el => el.classList.remove('dragging-over'));
-  rowDrag.targetFid = null;
-  rowDrag.targetWs  = null;
-
-  const el = document.elementFromPoint(e.clientX, e.clientY);
-
-  // Prefer a feature row as the drop target
-  const row = el?.closest('[data-fid]');
-  if (row) {
-    const targetFid = parseInt(row.dataset.fid);
-    if (targetFid !== rowDrag.fid) {
-      row.classList.add('dragging-over');
-      rowDrag.targetFid = targetFid;
-      return;
-    }
-  }
-
-  // Fall back to a workstream header (drop at end of that workstream)
-  const wsHeader = el?.closest('[data-wsid]');
-  if (wsHeader) {
-    const wsId = wsHeader.dataset.wsid;
-    if (wsId !== rowDrag.ws) {
-      wsHeader.classList.add('dragging-over');
-      rowDrag.targetWs = wsId;
-    }
-  }
-}
-
-function onRowDragUp() {
-  if (!rowDrag) return;
-  document.body.classList.remove('is-dragging');
-  document.querySelectorAll('.dragging-over').forEach(el => el.classList.remove('dragging-over'));
-  document.removeEventListener('mousemove', onRowDragMove);
-  document.removeEventListener('mouseup', onRowDragUp);
-
-  const { fid, targetFid, targetWs } = rowDrag;
-  rowDrag = null;
-
-  const src = state.features.find(x => x.id === fid);
-  if (!src) return;
-
-  if (targetFid && targetFid !== fid) {
-    // Drop onto another feature — insert before it (works across workstreams)
-    const tgt = state.features.find(x => x.id === targetFid);
-    if (!tgt) return;
-    src.ws = tgt.ws;
-    const si = state.features.indexOf(src);
-    state.features.splice(si, 1);
-    const ti = state.features.indexOf(tgt);
-    state.features.splice(ti, 0, src);
-    render();
-    persistState();
-  } else if (targetWs) {
-    // Drop onto a workstream header — append to end of that workstream
-    src.ws = targetWs;
-    render();
-    persistState();
-  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -9,10 +9,7 @@ import {
   pickStart, pickEnd, openSignInModal, closeSignInModal,
   openNewRoadmapModal, closeNewRoadmapModal,
 } from './modals.js';
-import {
-  startResize, doResize, stopResize, rowDragMouseDown, cellClick, startBarDrag,
-  startLabelResize, initLabelWidth,
-} from './interactions.js';
+import { startLabelResize, initLabelWidth } from './interactions.js';
 import { exportToPptx } from './export/exportPptx.js';
 import { exportToGoogleSlides } from './export/exportGoogleSlides.js';
 import {
@@ -23,6 +20,10 @@ import {
 } from './wizard.js';
 import { toggleWsCollapse, startWsRename } from './render.js';
 import { refreshConfigFromStartDate } from './config.js';
+import {
+  initAuth, showSignIn, signOut, submitSignIn,
+  loadRoadmap, saveRoadmap, newRoadmap, confirmNewRoadmap, subscribeRealtime,
+} from './auth.js';
 
 const THEME_KEY   = 'roadmap_theme';
 const THEMES      = ['gradient', 'gradient-dark'];
@@ -61,16 +62,13 @@ function toggleDensity() {
 }
 
 Object.assign(window, { toggleTheme, toggleDensity });
-import {
-  initAuth, isConfigured, showSignIn, signOut, submitSignIn,
-  loadRoadmap, saveRoadmap, newRoadmap, confirmNewRoadmap, subscribeRealtime,
-} from './auth.js';
 
-// Expose all functions called from inline onclick handlers in render()
+// Expose all functions called from inline onclick handlers
 Object.assign(window, {
-  render, openAddFeature, openEdit, openAddWorkstream, openEditWorkstream,
+  render,
+  openAddFeature, openEdit, openAddWorkstream, openEditWorkstream,
   saveFeature, deleteFeature, closeModal, saveWorkstream, deleteWorkstream,
-  pickStart, pickEnd, startResize, doResize, stopResize, rowDragMouseDown, cellClick, startBarDrag,
+  pickStart, pickEnd,
   exportToPptx, exportToGoogleSlides, exportStateAsJson,
   showSignIn, signOut, submitSignIn, openSignInModal, closeSignInModal,
   openNewRoadmapModal, closeNewRoadmapModal,
@@ -114,7 +112,6 @@ async function init() {
   _appReady = true;
   if (shouldShowWizard()) openWizard();
 
-  // Wire up roadmap name input
   const nameEl = document.getElementById('roadmap-name');
   if (nameEl) {
     nameEl.value = state.currentRoadmapName;

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,6 @@
 import { getConfig } from './config.js';
 import { state, persistState } from './state.js';
+import { initGantt } from './gantt.js';
 
 export function statusFor(id) {
   const cfg = getConfig();
@@ -10,66 +11,9 @@ export function isDark() {
   return document.documentElement.getAttribute('data-theme') === 'gradient-dark';
 }
 
-function barFill(st)  { return isDark() ? (st.darkFill  || st.fill)  : st.fill; }
-function barColor(st) { return isDark() ? (st.darkColor || st.color) : st.color; }
+// ── Stats bar ─────────────────────────────────────────────────────────────────
 
-function gridCols() {
-  const cfg = getConfig();
-  return `var(--label-w) ${cfg.months.map(() => cfg.colWidth + 'px').join(' ')}`;
-}
-
-const _collapsed = new Set();
-
-export function toggleWsCollapse(wsId) {
-  if (_collapsed.has(wsId)) _collapsed.delete(wsId);
-  else _collapsed.add(wsId);
-  render();
-}
-
-export function startWsRename(wsId) {
-  const header = document.querySelector(`.ws-header[data-wsid="${wsId}"]`);
-  if (!header) return;
-  const nameEl = header.querySelector('.ws-name');
-  if (!nameEl || nameEl.querySelector('input')) return;
-
-  const ws = state.workstreams.find(w => w.id === wsId);
-  if (!ws) return;
-
-  const input = document.createElement('input');
-  input.className = 'ws-name-inline';
-  input.value = ws.name;
-  nameEl.textContent = '';
-  nameEl.appendChild(input);
-  input.focus();
-  input.select();
-
-  let saved = false;
-
-  function save() {
-    if (saved) return;
-    saved = true;
-    const val = input.value.trim();
-    if (val && val !== ws.name) {
-      ws.name = val;
-      persistState();
-    }
-    render();
-  }
-
-  function cancel() {
-    if (saved) return;
-    saved = true;
-    render();
-  }
-
-  input.addEventListener('blur', save);
-  input.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') { e.preventDefault(); save(); }
-    if (e.key === 'Escape') { e.preventDefault(); cancel(); }
-  });
-}
-
-function renderStatsBar() {
+export function renderStatsBar() {
   const el = document.getElementById('stats-bar');
   if (!el) return;
   const cfg = getConfig();
@@ -105,86 +49,87 @@ function renderStatsBar() {
   `;
 }
 
-export function render() {
-  renderStatsBar();
+// ── Release band header ───────────────────────────────────────────────────────
 
+function renderReleaseHeader() {
+  const el = document.getElementById('release-header');
+  if (!el) return;
   const cfg = getConfig();
-  const filterWs = document.getElementById('filterWs').value;
-  const filterSt = document.getElementById('filterStatus').value;
-  const g = document.getElementById('gantt');
-  let html = '';
-
-  // Release band header
-  html += `<div class="release-row" style="display:grid;grid-template-columns:${gridCols()}">`;
-  html += `<div class="release-cell"></div>`;
-  cfg.months.forEach((m, i) => {
+  let html = '<div class="release-cell release-cell-label"></div>';
+  cfg.months.forEach((_, i) => {
     const rel = cfg.releases.find(r => r.start <= i && i <= r.end);
     if (rel && i === rel.start) {
       const span = rel.end - rel.start + 1;
       html += `<div class="release-cell" style="grid-column:span ${span};background:${rel.bg};color:${rel.color || ''}">${rel.label}</div>`;
     } else if (!rel) {
-      html += `<div class="release-cell"></div>`;
+      html += '<div class="release-cell"></div>';
     }
   });
-  html += '</div>';
+  el.innerHTML = html;
+}
 
-  // Month header row
-  html += `<div class="gantt-header" style="display:grid;grid-template-columns:${gridCols()}">`;
-  html += `<div class="month-cell label-col-header" style="text-align:left;padding-left:10px">Workstream / Feature<div class="label-col-resizer" onmousedown="startLabelResize(event)"></div></div>`;
-  cfg.months.forEach((m, i) => {
-    html += `<div class="month-cell${i === cfg.currentMonth ? ' current' : ''}">${m}</div>`;
-  });
-  html += '</div>';
+// ── Collapsible workstreams ───────────────────────────────────────────────────
 
-  // One section per workstream
-  state.workstreams.forEach(ws => {
-    if (filterWs && ws.id !== filterWs) return;
-    const wsFeatures = state.features.filter(f => f.ws === ws.id && (!filterSt || f.status === filterSt));
-    const collapsed = _collapsed.has(ws.id);
+const _collapsed = new Set();
 
-    html += `<div class="ws-section">`;
-    html += `<div class="ws-header" data-wsid="${ws.id}">
-      <button class="ws-collapse-btn${collapsed ? ' collapsed' : ''}" onclick="toggleWsCollapse('${ws.id}')" aria-expanded="${!collapsed}" title="${collapsed ? 'Expand' : 'Collapse'}">▾</button>
-      <div class="ws-dot" style="background:${ws.color}"></div>
-      <div class="ws-name" ondblclick="startWsRename('${ws.id}')" title="Double-click to rename">${ws.name}</div>
-      <div class="ws-actions">
-        <button onclick="openAddFeature('${ws.id}')">+ feature</button>
-        <button onclick="openEditWorkstream('${ws.id}')">edit</button>
-      </div>
-    </div>`;
+export function toggleWsCollapse(wsId) {
+  if (_collapsed.has(wsId)) _collapsed.delete(wsId);
+  else _collapsed.add(wsId);
+  render();
+}
 
-    if (!collapsed) {
-      wsFeatures.forEach(f => {
-        const st = statusFor(f.status);
-        html += `<div class="feature-row" data-fid="${f.id}" style="display:grid;grid-template-columns:${gridCols()}">`;
+// ── Inline workstream rename ──────────────────────────────────────────────────
 
-        html += `<div class="feature-label">
-          <span class="drag-handle" onmousedown="rowDragMouseDown(event,${f.id})">⠿</span>
-          <span onclick="openEdit(${f.id})" style="cursor:pointer">${f.name}</span>
-        </div>`;
+export function startWsRename(wsId) {
+  const header = document.querySelector(`.vis-ws-header[data-wsid="${wsId}"]`);
+  if (!header) return;
+  const nameEl = header.querySelector('.ws-name');
+  if (!nameEl || nameEl.querySelector('input')) return;
 
-        cfg.months.forEach((_, i) => {
-          const isStart = i === f.start;
-          const totalW = (f.end - f.start + 1) * cfg.colWidth - 8;
-          html += `<div class="cell${i % 2 ? ' alt' : ''}" onclick="cellClick(${f.id},${i})">`;
-          if (isStart) {
-            const grips = `<span class="grip-dot"></span><span class="grip-dot"></span><span class="grip-dot"></span>`;
-            html += `<div class="bar"
-              style="left:4px;width:${totalW}px;background:${barFill(st)};color:${barColor(st)}"
-              onmousedown="startBarDrag(event,${f.id})">
-              <div class="bar-resize-l" onmousedown="startResize(event,${f.id},'l')">${grips}</div>
-              <span style="flex:1;overflow:hidden;text-overflow:ellipsis;pointer-events:none;padding:0 2px">${f.name}</span>
-              <div class="bar-resize-r" onmousedown="startResize(event,${f.id},'r')">${grips}</div>
-            </div>`;
-          }
-          html += '</div>';
-        });
-        html += '</div>';
-      });
+  const ws = state.workstreams.find(w => w.id === wsId);
+  if (!ws) return;
+
+  const input = document.createElement('input');
+  input.className = 'ws-name-inline';
+  input.value = ws.name;
+  nameEl.textContent = '';
+  nameEl.appendChild(input);
+  input.focus();
+  input.select();
+
+  let saved = false;
+
+  function save() {
+    if (saved) return;
+    saved = true;
+    const val = input.value.trim();
+    if (val && val !== ws.name) {
+      ws.name = val;
+      persistState();
     }
+    render();
+  }
 
-    html += '</div>';
+  function cancel() {
+    if (saved) return;
+    saved = true;
+    render();
+  }
+
+  input.addEventListener('blur', save);
+  input.addEventListener('keydown', e => {
+    if (e.key === 'Enter') { e.preventDefault(); save(); }
+    if (e.key === 'Escape') { e.preventDefault(); cancel(); }
   });
+}
 
-  g.innerHTML = html;
+// ── Main render ───────────────────────────────────────────────────────────────
+
+export function render() {
+  renderStatsBar();
+  renderReleaseHeader();
+
+  const filterWs = document.getElementById('filterWs')?.value ?? '';
+  const filterSt = document.getElementById('filterStatus')?.value ?? '';
+  initGantt(filterWs, filterSt, _collapsed);
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,3 +1,5 @@
+@import '../../node_modules/vis-timeline/styles/vis-timeline-graph2d.min.css';
+
 /* ── Certinia Design Tokens ─────────────────────────────────────────────────── */
 :root {
   --font-display: 'Bodoni Moda', Georgia, serif;
@@ -109,37 +111,129 @@ button { font-family: var(--font-body); cursor: pointer; }
   background:var(--bg);color:var(--text);
 }
 
-/* ── Gantt ──────────────────────────────────────────────────────────────────── */
+/* ── Gantt wrapper ───────────────────────────────────────────────────────────── */
 .gantt-wrap { overflow-x:auto }
-.gantt { min-width:900px;font-size:11px;user-select:none }
-.gantt-header { display:grid;background:var(--bg-2);border-bottom:1px solid var(--border-2) }
-.month-cell {
-  padding:5px 2px;text-align:center;font-weight:500;font-size:10px;
-  font-family:var(--font-body);color:var(--text-2);
-  border-right:1px solid var(--border-2);
-  text-transform:uppercase;letter-spacing:.04em;
-}
-.month-cell.current { background:var(--current-m);color:#fff }
 
-.release-row { display:grid;border-bottom:1px solid var(--border-2) }
+/* ── Release band header ────────────────────────────────────────────────────── */
+.gantt-release-header {
+  display:grid;
+  grid-template-columns: var(--label-w) repeat(12, 1fr);
+  border-bottom:1px solid var(--border-2);
+  min-width:900px;
+}
 .release-cell {
   padding:3px 6px;text-align:center;font-size:10px;font-weight:600;
   font-family:var(--font-body);border-right:1px solid var(--border-2);
-  text-transform:uppercase;letter-spacing:.04em;
+  text-transform:uppercase;letter-spacing:.04em;color:inherit;
+}
+.release-cell-label { background:var(--bg-2) }
+
+/* ── vis-timeline overrides ──────────────────────────────────────────────────── */
+#gantt { min-width:900px; user-select:none }
+
+/* Container */
+.vis-timeline { border:none !important; font-family:var(--font-body) !important; background:var(--bg) !important; }
+
+/* Left label panel */
+.vis-panel.vis-left {
+  min-width:var(--label-w) !important;
+  max-width:var(--label-w) !important;
+  border-right:1px solid var(--border-2) !important;
+  overflow:hidden;
+  position:relative !important;
 }
 
-.ws-section { border-bottom:1px solid var(--border) }
-.ws-header {
-  display:flex;align-items:center;gap:6px;padding:6px 8px;
-  height:38px;background:var(--bg-2);border-bottom:1px solid var(--border-2);
-  position:sticky;left:0;
+/* Label resize handle */
+.vis-panel.vis-left .label-col-resizer {
+  position:absolute;top:0;right:0;bottom:0;width:6px;
+  cursor:col-resize;z-index:10;
+}
+.vis-panel.vis-left .label-col-resizer::after {
+  content:'';position:absolute;top:20%;right:1px;bottom:20%;
+  width:2px;border-radius:1px;background:var(--border);opacity:0;transition:opacity .15s;
+}
+.vis-panel.vis-left:hover .label-col-resizer::after { opacity:1 }
+
+/* Group label rows */
+.vis-labelset .vis-label {
+  border-bottom:1px solid var(--border-2) !important;
+  background:var(--bg-2) !important;
+  padding:0 !important;
+}
+.vis-labelset .vis-label .vis-inner { padding:0 !important; width:100% !important; }
+
+/* Top panel / time axis */
+.vis-panel.vis-top { border-bottom:1px solid var(--border-2) !important; background:var(--bg-2) !important; }
+.vis-time-axis { background:var(--bg-2) !important; }
+.vis-time-axis .vis-text {
+  font-family:var(--font-body) !important;
+  font-size:10px !important;
+  font-weight:500 !important;
+  color:var(--text-2) !important;
+  text-transform:uppercase !important;
+  letter-spacing:.04em !important;
+  padding:5px 2px !important;
+}
+.vis-time-axis .vis-text.vis-major { display:none !important; }
+
+/* Grid lines */
+.vis-panel.vis-center { border-left:none !important; }
+.vis-grid.vis-minor { border-left-color:var(--border-2) !important; }
+.vis-grid.vis-major { display:none !important; }
+
+/* Feature bars */
+.vis-item.vis-range {
+  border-radius:4px !important;
+  border:none !important;
+  font-family:var(--font-body) !important;
+  font-size:10px !important;
+  font-weight:500 !important;
+  cursor:grab !important;
+  transition:filter .1s !important;
+  box-shadow:none !important;
+}
+.vis-item.vis-range:hover { filter:brightness(1.06) !important; }
+.vis-item.vis-range.vis-selected {
+  border:none !important;
+  outline:2px solid var(--accent-2) !important;
+  outline-offset:1px !important;
+  box-shadow:none !important;
+}
+.vis-item .vis-item-content {
+  font-family:var(--font-body) !important;
+  padding:0 8px !important;
+  white-space:nowrap !important;
+  overflow:hidden !important;
+  text-overflow:ellipsis !important;
+}
+.vis-item .vis-item-handle {
+  background:transparent !important;
+  border:none !important;
+  width:8px !important;
+  cursor:ew-resize !important;
+}
+
+/* Background bands */
+.vis-item.vis-background { z-index:0 !important; cursor:default !important; border:none !important; }
+.vis-item.vis-background.vis-current-month {
+  background:rgba(57,39,255,.07) !important;
+}
+
+/* Row background */
+.vis-panel.vis-center .vis-group:nth-child(even) { background:rgba(0,0,0,.012) }
+
+/* Workstream header inside vis group label */
+.vis-ws-header {
+  display:flex;align-items:center;gap:6px;
+  padding:6px 8px;height:38px;width:100%;box-sizing:border-box;
 }
 .ws-dot { width:9px;height:9px;border-radius:50%;flex-shrink:0 }
 .ws-name {
   font-weight:600;font-size:12px;color:var(--text);
   letter-spacing:-.01em;font-family:var(--font-body);
+  flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
 }
-.ws-actions { margin-left:auto;display:flex;gap:4px }
+.ws-actions { display:flex;gap:4px;flex-shrink:0 }
 .ws-actions button {
   font-size:10px;padding:2px 7px;
   border:1px solid var(--border-2);border-radius:var(--radius);
@@ -148,41 +242,7 @@ button { font-family: var(--font-body); cursor: pointer; }
 }
 .ws-actions button:hover { background:var(--bg-3);color:var(--text) }
 
-.feature-row { display:grid;align-items:center;min-height:36px;border-bottom:1px solid var(--border-2) }
-.feature-row:hover { background:var(--bg-2) }
-.feature-row.dragging-over { background:rgba(57,39,255,.06);opacity:.8 }
-
-.feature-label {
-  padding:0 8px;font-size:11px;font-weight:500;font-family:var(--font-body);
-  color:var(--text-3);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
-  cursor:default;display:flex;align-items:center;gap:4px;
-}
-.feature-label .drag-handle { cursor:grab;color:var(--text-3);font-size:13px }
-.feature-label span:not(.drag-handle):hover { color:var(--accent-2) }
-
-.cell { border-right:1px solid var(--border-2);height:100%;min-height:36px;position:relative;cursor:pointer }
-.cell.alt { background:rgba(0,0,0,.012) }
-
-.bar {
-  position:absolute;top:6px;bottom:6px;border-radius:4px;
-  display:flex;align-items:center;padding:0 8px;
-  font-size:10px;font-weight:500;font-family:var(--font-body);
-  white-space:nowrap;overflow:hidden;cursor:grab;
-  transition:filter .1s, opacity .1s;
-}
-.bar:hover { filter:brightness(1.05) }
-.bar .bar-resize-l,.bar .bar-resize-r {
-  position:absolute;top:0;bottom:0;width:8px;cursor:ew-resize;z-index:2;
-  display:flex;flex-direction:column;justify-content:center;align-items:center;gap:2px;
-  opacity:.5;
-}
-.bar:hover .bar-resize-l,.bar:hover .bar-resize-r { opacity:1 }
-.bar .bar-resize-l { left:2px }
-.bar .bar-resize-r { right:2px }
-.bar .grip-dot { width:3px;height:3px;border-radius:50%;background:currentColor }
-
-body.is-dragging { cursor:grabbing }
-body.is-dragging .bar, body.is-dragging .bar * { pointer-events:none }
+body.is-dragging { cursor:grabbing !important }
 
 /* ── Legend ─────────────────────────────────────────────────────────────────── */
 .legend {
@@ -394,21 +454,11 @@ body.is-dragging .bar, body.is-dragging .bar * { pointer-events:none }
 .ws-collapse-btn:hover { background:var(--bg-3);color:var(--text) }
 .ws-collapse-btn.collapsed { transform:rotate(-90deg) }
 
-/* ── Label column resizer ────────────────────────────────────────────────────── */
-.label-col-header { position:relative; overflow:visible !important }
-.label-col-resizer {
-  position:absolute;top:0;right:0;bottom:0;width:6px;
-  cursor:col-resize;z-index:3;
-}
-.label-col-resizer::after {
-  content:'';position:absolute;top:20%;right:1px;bottom:20%;
-  width:2px;border-radius:1px;background:var(--border);opacity:0;transition:opacity .15s;
-}
-.label-col-header:hover .label-col-resizer::after { opacity:1 }
 
 /* ── Row density ─────────────────────────────────────────────────────────────── */
-.gantt.compact .feature-row { min-height:28px }
-.gantt.compact .bar { top:4px;bottom:4px }
+#gantt.compact .vis-item.vis-range { height:20px !important; line-height:20px !important; }
+#gantt.compact .vis-labelset .vis-label { min-height:30px !important; }
+#gantt.compact .vis-ws-header { height:30px !important; }
 
 /* ── Inline workstream rename ────────────────────────────────────────────────── */
 .ws-name-inline {


### PR DESCRIPTION
- Install vis-timeline (MIT) via npm
- New src/gantt.js: initialises Timeline with state.workstreams as groups and state.features as items; onMove callback persists state and supports cross-workstream drag natively; click-to-select opens the edit modal; current-month highlighted as a background band
- Release band header rendered as CSS-grid HTML row above the timeline, aligned via --label-w CSS variable so columns line up with vis axis
- src/render.js: render() now calls renderStatsBar() + renderReleaseHeader()
  + initGantt(); all vis group content includes collapse button and inline rename support (onclick handlers on window as before)
- src/interactions.js: removed bar drag/resize/cellClick/rowDrag (all handled natively by vis-timeline); kept label column resize
- vis-timeline CSS imported via @import in main.css; overrides applied to match Certinia design tokens (Poppins font, design-system colours, border vars, item radius, axis styling)
- Dark mode bar colours (darkFill/darkColor) applied in vis item styles